### PR TITLE
AES-GCM AEAD Cipher Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This library retains its original [3-Clause BSD license](
 https://opensource.org/licenses/BSD-3-Clause).
 
 ##### Encryption:
-  * chacha20-poly1305@openssh.com ([draft-ietf-sshm-chacha20-poly1305](https://datatracker.ietf.org/doc/html/draft-ietf-sshm-chacha20-poly1305)) - **AEAD cipher, requires Java 11+**
+  * chacha20-poly1305\@openssh.com ([draft-ietf-sshm-chacha20-poly1305](https://datatracker.ietf.org/doc/html/draft-ietf-sshm-chacha20-poly1305))
+  * aes256-gcm\@openssh.com ([RFC 5647](https://tools.ietf.org/html/rfc5647), [draft-miller-sshm-aes-gcm](https://datatracker.ietf.org/doc/html/draft-miller-sshm-aes-gcm))
+  * aes128-gcm\@openssh.com ([RFC 5647](https://tools.ietf.org/html/rfc5647), [draft-miller-sshm-aes-gcm](https://datatracker.ietf.org/doc/html/draft-miller-sshm-aes-gcm))
   * aes256-ctr ([RFC 4344](https://tools.ietf.org/html/rfc4344#section-4))
   * aes128-ctr ([RFC 4344](https://tools.ietf.org/html/rfc4344#section-4))
   * aes256-cbc ([RFC 4253](https://tools.ietf.org/html/rfc4253#section-6.3))
@@ -20,11 +22,11 @@ https://opensource.org/licenses/BSD-3-Clause).
   * 3des-cbc ([RFC 4253](https://tools.ietf.org/html/rfc4253#section-6.3))
 
 ##### MACs:
-  * hmac-sha2-512-etm@openssh.com ([OpenSSH PROTOCOL](
+  * hmac-sha2-512-etm\@openssh.com ([OpenSSH PROTOCOL](
     https://github.com/openssh/openssh-portable/blob/e1b26ce504662a5d5b991091228984ccfd25f280/PROTOCOL#L54))
-  * hmac-sha2-256-etm@openssh.com ([OpenSSH PROTOCOL](
+  * hmac-sha2-256-etm\@openssh.com ([OpenSSH PROTOCOL](
     https://github.com/openssh/openssh-portable/blob/e1b26ce504662a5d5b991091228984ccfd25f280/PROTOCOL#L54))
-  * hmac-sha1-etm@openssh.com ([OpenSSH PROTOCOL](
+  * hmac-sha1-etm\@openssh.com ([OpenSSH PROTOCOL](
     https://github.com/openssh/openssh-portable/blob/e1b26ce504662a5d5b991091228984ccfd25f280/PROTOCOL#L54))
   * hmac-sha2-512 ([RFC 4868](https://tools.ietf.org/html/rfc4868))
   * hmac-sha2-256 ([RFC 4868](https://tools.ietf.org/html/rfc4868))

--- a/src/main/java/com/trilead/ssh2/crypto/cipher/AeadCipher.java
+++ b/src/main/java/com/trilead/ssh2/crypto/cipher/AeadCipher.java
@@ -6,9 +6,6 @@ package com.trilead.ssh2.crypto.cipher;
  * AEAD ciphers combine encryption and authentication in a single operation,
  * unlike traditional SSH ciphers that use separate cipher and MAC algorithms.
  *
- * This interface supports the OpenSSH ChaCha20-Poly1305 AEAD cipher
- * (chacha20-poly1305@openssh.com) as specified in draft-ietf-sshm-chacha20-poly1305-02.
- *
  * @author Kenny Root
  */
 public interface AeadCipher
@@ -17,10 +14,11 @@ public interface AeadCipher
 	 * Initialize the AEAD cipher for encryption or decryption.
 	 *
 	 * @param forEncryption true for encryption, false for decryption
-	 * @param key key material (size depends on cipher, e.g., 64 bytes for ChaCha20-Poly1305)
-	 * @throws IllegalArgumentException if key size is invalid
+	 * @param key encryption key material (size depends on cipher)
+	 * @param iv initial IV material (size depends on cipher, may be unused for some AEAD ciphers)
+	 * @throws IllegalArgumentException if key or IV size is invalid
 	 */
-	void init(boolean forEncryption, byte[] key) throws IllegalArgumentException;
+	void init(boolean forEncryption, byte[] key, byte[] iv) throws IllegalArgumentException;
 
 	/**
 	 * Get the key size in bytes required by this cipher.
@@ -35,6 +33,13 @@ public interface AeadCipher
 	 * @return tag size in bytes
 	 */
 	int getTagSize();
+
+	/**
+	 * Gets the block size of the cipher.
+	 *
+	 * @return block size in bytes
+	 */
+	int getBlockSize();
 
 	/**
 	 * Encrypt the 4-byte packet length field.

--- a/src/main/java/com/trilead/ssh2/crypto/cipher/AesGcm.java
+++ b/src/main/java/com/trilead/ssh2/crypto/cipher/AesGcm.java
@@ -1,0 +1,244 @@
+package com.trilead.ssh2.crypto.cipher;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+
+/**
+ * AES-GCM AEAD cipher implementation for SSH.
+ *
+ * Implements aes128-gcm@openssh.com and aes256-gcm@openssh.com as specified in:
+ * - RFC 5647: AES Galois Counter Mode for SSH Transport Layer Protocol
+ * - draft-miller-sshm-aes-gcm-00: OpenSSH modifications fixing RFC 5647 negotiation
+ *
+ * Packet format:
+ *   [4 bytes plaintext length (AAD)] [encrypted payload] [16 bytes GCM tag]
+ *
+ * Nonce construction:
+ *   [4 bytes fixed IV] [8 bytes invocation counter]
+ *
+ * @author Kenny Root
+ */
+public class AesGcm implements AeadCipher
+{
+	public static final int BLOCK_SIZE = 16;
+	public static final int TAG_SIZE = 16;  // 128 bits
+	public static final int NONCE_SIZE = 12; // 96 bits
+	public static final int FIXED_IV_SIZE = 4; // First 4 bytes of initial IV
+
+	private final int keyBytes;
+	private SecretKeySpec keySpec;
+	private byte[] nonce;
+	private byte[] initialNonce;
+	private boolean forEncryption;
+
+	private Cipher cipher;
+
+	private byte[] tempBuffer;
+	private int tempBufferSize = 0;
+
+	/**
+	 * Create an AES-GCM cipher instance.
+	 *
+	 * @param keyBits key size in bits (128 or 256)
+	 * @throws IllegalArgumentException if keyBits is not 128 or 256
+	 */
+	public AesGcm(int keyBits) throws IllegalArgumentException
+	{
+		if (keyBits != 128 && keyBits != 256)
+		{
+			throw new IllegalArgumentException("Key size must be 128 or 256 bits");
+		}
+		this.keyBytes = keyBits / 8;
+	}
+
+	@Override
+	public void init(boolean forEncryption, byte[] key, byte[] iv) throws IllegalArgumentException
+	{
+		if (key.length != keyBytes)
+		{
+			throw new IllegalArgumentException(
+				"Invalid key length: expected " + keyBytes + ", got " + key.length);
+		}
+
+		if (iv.length != NONCE_SIZE)
+		{
+			throw new IllegalArgumentException(
+				"Invalid IV length: expected " + NONCE_SIZE + ", got " + iv.length);
+		}
+
+		this.forEncryption = forEncryption;
+
+		this.keySpec = new SecretKeySpec(key, "AES");
+
+		this.nonce = new byte[NONCE_SIZE];
+		System.arraycopy(iv, 0, this.nonce, 0, NONCE_SIZE);
+
+		this.initialNonce = new byte[NONCE_SIZE];
+		System.arraycopy(this.nonce, 0, this.initialNonce, 0, NONCE_SIZE);
+
+		try
+		{
+			this.cipher = Cipher.getInstance("AES/GCM/NoPadding");
+		}
+		catch (GeneralSecurityException e)
+		{
+			throw new IllegalStateException("AES/GCM/NoPadding not available", e);
+		}
+	}
+
+	@Override
+	public int getKeySize()
+	{
+		return keyBytes;
+	}
+
+	@Override
+	public int getTagSize()
+	{
+		return TAG_SIZE;
+	}
+
+	/**
+	 * Ensure the temporary buffer is at least the specified size.
+	 * Reuses existing buffer if large enough to reduce allocations.
+	 */
+	private void ensureTempBufferSize(int requiredSize)
+	{
+		if (tempBuffer == null || tempBufferSize < requiredSize)
+		{
+			tempBuffer = new byte[requiredSize];
+			tempBufferSize = requiredSize;
+		}
+	}
+
+	/**
+	 * Increment the nonce for the next packet.
+	 *
+	 * The nonce is treated as a 96-bit (12-byte) big-endian counter that is incremented
+	 * after each packet.
+	 */
+	private void incrementNonce()
+	{
+		for (int i = NONCE_SIZE - 1; i >= 0; i--)
+		{
+			nonce[i]++;
+			if (nonce[i] != 0)
+			{
+				break;
+			}
+		}
+
+		if (Arrays.equals(nonce, initialNonce))
+		{
+			throw new IllegalStateException("GCM nonce counter wrapped - rekey required");
+		}
+	}
+
+	@Override
+	public void encryptPacketLength(int seqNum, byte[] plainLength, byte[] dest, int destOff)
+	{
+		// AES-GCM does NOT encrypt the packet length (it's used as AAD instead)
+		System.arraycopy(plainLength, 0, dest, destOff, 4);
+	}
+
+	@Override
+	public void decryptPacketLength(int seqNum, byte[] encryptedLength, byte[] dest, int destOff)
+	{
+		// AES-GCM does NOT encrypt the packet length (it's plaintext AAD)
+		System.arraycopy(encryptedLength, 0, dest, destOff, 4);
+	}
+
+	@Override
+	public void seal(int seqNum, byte[] plaintext, byte[] ciphertext, byte[] tag, byte[] encryptedLength)
+	{
+		if (!forEncryption)
+		{
+			throw new IllegalStateException("AES-GCM not initialized for encryption");
+		}
+
+		try
+		{
+			GCMParameterSpec spec = new GCMParameterSpec(TAG_SIZE * 8, nonce);
+			cipher.init(Cipher.ENCRYPT_MODE, keySpec, spec);
+
+			cipher.updateAAD(encryptedLength, 0, 4);
+
+			int requiredSize = plaintext.length + TAG_SIZE;
+			ensureTempBufferSize(requiredSize);
+
+			int outputLen = cipher.doFinal(plaintext, 0, plaintext.length, tempBuffer, 0);
+
+			System.arraycopy(tempBuffer, 0, ciphertext, 0, plaintext.length);
+			System.arraycopy(tempBuffer, plaintext.length, tag, 0, TAG_SIZE);
+
+			incrementNonce();
+		}
+		catch (GeneralSecurityException e)
+		{
+			throw new IllegalStateException("AES-GCM encryption failed", e);
+		}
+	}
+
+	@Override
+	public boolean open(int seqNum, byte[] ciphertext, byte[] tag, byte[] plaintext, byte[] encryptedLength)
+	{
+		if (forEncryption)
+		{
+			throw new IllegalStateException("AES-GCM not initialized for decryption");
+		}
+
+		try
+		{
+			GCMParameterSpec spec = new GCMParameterSpec(TAG_SIZE * 8, nonce);
+			cipher.init(Cipher.DECRYPT_MODE, keySpec, spec);
+
+			cipher.updateAAD(encryptedLength, 0, 4);
+
+			int requiredSize = ciphertext.length + TAG_SIZE;
+			ensureTempBufferSize(requiredSize);
+
+			System.arraycopy(ciphertext, 0, tempBuffer, 0, ciphertext.length);
+			System.arraycopy(tag, 0, tempBuffer, ciphertext.length, TAG_SIZE);
+
+			int outputLen = cipher.doFinal(tempBuffer, 0, requiredSize, plaintext, 0);
+
+			incrementNonce();
+
+			return true;
+		}
+		catch (GeneralSecurityException e)
+		{
+			return false;
+		}
+	}
+
+	@Override
+	public int getBlockSize() {
+		return BLOCK_SIZE;
+	}
+
+	/**
+	 * AES-128-GCM cipher (16-byte key + 12-byte IV = 28 bytes key material).
+	 */
+	public static class AES128 extends AesGcm
+	{
+		public AES128()
+		{
+			super(128);
+		}
+	}
+
+	/**
+	 * AES-256-GCM cipher (32-byte key + 12-byte IV = 44 bytes key material).
+	 */
+	public static class AES256 extends AesGcm
+	{
+		public AES256()
+		{
+			super(256);
+		}
+	}
+}

--- a/src/main/java/com/trilead/ssh2/crypto/cipher/ChaCha20Poly1305.java
+++ b/src/main/java/com/trilead/ssh2/crypto/cipher/ChaCha20Poly1305.java
@@ -29,12 +29,12 @@ import java.util.Arrays;
 public class ChaCha20Poly1305 implements AeadCipher
 {
 	public static final String SSH_NAME = "chacha20-poly1305@openssh.com";
+	public static final int BLOCK_SIZE = 8;
 	public static final int KEY_SIZE = 64;  // 2 x 32-byte keys
 	public static final int TAG_SIZE = 16;  // Poly1305 tag
 
 	private byte[] mainKey;     // K_1: first 32 bytes
 	private byte[] headerKey;   // K_2: second 32 bytes
-	private boolean forEncryption;
 
 	// Reusable cipher instances to reduce garbage
 	private Cipher headerCipher;
@@ -53,14 +53,12 @@ public class ChaCha20Poly1305 implements AeadCipher
 	private final byte[] computedTag = new byte[TAG_SIZE];
 
 	@Override
-	public void init(boolean forEncryption, byte[] key) throws IllegalArgumentException
+	public void init(boolean forEncryption, byte[] key, byte[] iv) throws IllegalArgumentException
 	{
 		if (key.length != KEY_SIZE)
 		{
 			throw new IllegalArgumentException("ChaCha20-Poly1305 requires 64 bytes of key material");
 		}
-
-		this.forEncryption = forEncryption;
 
 		// Copy keys
 		if (this.mainKey == null)
@@ -286,5 +284,10 @@ public class ChaCha20Poly1305 implements AeadCipher
 			result |= a[i] ^ b[i];
 		}
 		return result == 0;
+	}
+
+	@Override
+	public int getBlockSize() {
+		return BLOCK_SIZE;
 	}
 }

--- a/src/main/java/com/trilead/ssh2/transport/TransportConnection.java
+++ b/src/main/java/com/trilead/ssh2/transport/TransportConnection.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import java.security.SecureRandom;
 
 import com.trilead.ssh2.compression.ICompressor;
+import com.trilead.ssh2.crypto.cipher.AeadCipher;
 import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.cipher.CipherInputStream;
 import com.trilead.ssh2.crypto.cipher.CipherOutputStream;
@@ -52,9 +53,9 @@ public class TransportConnection
 
 	int recv_padd_blocksize = 8;
 
-	com.trilead.ssh2.crypto.cipher.AeadCipher send_aead_cipher;
+	AeadCipher send_aead_cipher;
 
-	com.trilead.ssh2.crypto.cipher.AeadCipher recv_aead_cipher;
+	AeadCipher recv_aead_cipher;
 
 	boolean send_is_aead = false;
 
@@ -121,18 +122,22 @@ public class TransportConnection
 			send_padd_blocksize = 8;
 	}
 
-	public void changeRecvAeadCipher(com.trilead.ssh2.crypto.cipher.AeadCipher cipher)
+	public void changeRecvAeadCipher(AeadCipher cipher)
 	{
 		recv_aead_cipher = cipher;
 		recv_is_aead = true;
-		recv_padd_blocksize = 8;  // ChaCha20-Poly1305 uses 8-byte alignment
+		recv_padd_blocksize = cipher.getBlockSize();
+		if (recv_padd_blocksize < 8)
+			recv_padd_blocksize = 8;
 	}
 
-	public void changeSendAeadCipher(com.trilead.ssh2.crypto.cipher.AeadCipher cipher)
+	public void changeSendAeadCipher(AeadCipher cipher)
 	{
 		send_aead_cipher = cipher;
 		send_is_aead = true;
-		send_padd_blocksize = 8;  // ChaCha20-Poly1305 uses 8-byte alignment
+		send_padd_blocksize = cipher.getBlockSize();
+		if (send_padd_blocksize < 8)
+			send_padd_blocksize = 8;
 		useRandomPadding = true;  // Always use random padding with AEAD
 	}
 

--- a/src/test/java/com/trilead/ssh2/OpenSSHCompatibilityTest.java
+++ b/src/test/java/com/trilead/ssh2/OpenSSHCompatibilityTest.java
@@ -252,6 +252,21 @@ public class OpenSSHCompatibilityTest {
 		assertCanConnectToServerWithCipher("3des-cbc");
 	}
 
+	@Test
+	public void canConnectWithCipherAes128Gcm() throws Exception {
+		assertCanConnectToServerWithCipher("aes128-gcm@openssh.com");
+	}
+
+	@Test
+	public void canConnectWithCipherAes256Gcm() throws Exception {
+		assertCanConnectToServerWithCipher("aes256-gcm@openssh.com");
+	}
+
+	@Test
+	public void canConnectWithCipherChaCha20Poly1305() throws Exception {
+		assertCanConnectToServerWithCipher("chacha20-poly1305@openssh.com");
+	}
+
 	private void assertCanConnectToServerWithMac(@NotNull String macs) throws IOException {
 		ConnectionInfo info = connectToServerWithOptions("-oMACs=" + macs);
 		assertThat(macs, is(info.clientToServerMACAlgorithm));

--- a/src/test/java/com/trilead/ssh2/crypto/cipher/AesGcmTest.java
+++ b/src/test/java/com/trilead/ssh2/crypto/cipher/AesGcmTest.java
@@ -1,0 +1,470 @@
+package com.trilead.ssh2.crypto.cipher;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for AES-GCM AEAD cipher implementation.
+ *
+ * Tests both AES-128-GCM and AES-256-GCM variants with various test vectors
+ * and edge cases.
+ */
+public class AesGcmTest {
+	private static final SecureRandom random = new SecureRandom();
+
+	@Test
+	public void testAes128GcmRoundTrip() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+
+		// Key material: 16 bytes key + 12 bytes IV = 28 bytes
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		// Prepare test data
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x20 }; // 32 bytes
+		byte[] payload = "Test payload for AES-GCM encryption".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		// Encrypt
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Decrypt
+		AesGcm decipher = new AesGcm(128);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] decryptedLength = new byte[4];
+		byte[] plaintext = new byte[payload.length];
+
+		decipher.decryptPacketLength(1, encryptedLength, decryptedLength, 0);
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertTrue(valid, "Tag verification should succeed");
+		assertArrayEquals(payload, plaintext, "Plaintext should match");
+		assertArrayEquals(plainLength, decryptedLength, "Length should match (not encrypted for AES-GCM)");
+	}
+
+	@Test
+	public void testAes256GcmRoundTrip() throws Exception {
+		AesGcm cipher = new AesGcm(256);
+
+		// Key material: 32 bytes key + 12 bytes IV = 44 bytes
+		byte[] keyMaterial = new byte[44];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		// Prepare test data
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 }; // 16 bytes
+		byte[] payload = "Test payload 256".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		// Encrypt
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Decrypt
+		AesGcm decipher = new AesGcm(256);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] decryptedLength = new byte[4];
+		byte[] plaintext = new byte[payload.length];
+
+		decipher.decryptPacketLength(1, encryptedLength, decryptedLength, 0);
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertTrue(valid, "Tag verification should succeed");
+		assertArrayEquals(payload, plaintext, "Plaintext should match");
+	}
+
+	@Test
+	public void testAes128GcmInvalidTag() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test payload".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Corrupt tag
+		tag[tag.length - 1] ^= 0xFF;
+
+		// Decrypt should fail
+		AesGcm decipher = new AesGcm(128);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] plaintext = new byte[payload.length];
+
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertFalse(valid, "Tag verification should fail");
+	}
+
+	@Test
+	public void testAes256GcmInvalidTag() throws Exception {
+		AesGcm cipher = new AesGcm(256);
+		byte[] keyMaterial = new byte[44];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test payload".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Corrupt tag (first byte)
+		tag[0] ^= 0xFF;
+
+		// Decrypt should fail
+		AesGcm decipher = new AesGcm(256);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] plaintext = new byte[payload.length];
+
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertFalse(valid, "Tag verification should fail");
+	}
+
+	@Test
+	public void testNonceUniqueness() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test payload".getBytes();
+		byte[] encryptedLength = new byte[4];
+
+		// Encrypt same plaintext with different sequence numbers
+		byte[] ciphertext1 = new byte[payload.length];
+		byte[] tag1 = new byte[16];
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext1, tag1, encryptedLength);
+
+		byte[] ciphertext2 = new byte[payload.length];
+		byte[] tag2 = new byte[16];
+		cipher.encryptPacketLength(2, plainLength, encryptedLength, 0);
+		cipher.seal(2, payload, ciphertext2, tag2, encryptedLength);
+
+		// Ciphertexts should be different due to different nonces
+		assertFalse(Arrays.equals(ciphertext1, ciphertext2),
+				"Ciphertexts should differ with different sequence numbers");
+		assertFalse(Arrays.equals(tag1, tag2),
+				"Tags should differ with different sequence numbers");
+	}
+
+	@Test
+	public void testAADModification() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test payload".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Modify AAD (the length field)
+		byte[] modifiedLength = encryptedLength.clone();
+		modifiedLength[3] ^= 0x01;
+
+		// Decrypt with modified AAD should fail
+		AesGcm decipher = new AesGcm(128);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] plaintext = new byte[payload.length];
+
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, modifiedLength);
+
+		assertFalse(valid, "Tag verification should fail when AAD is modified");
+	}
+
+	@Test
+	public void testCiphertextModification() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test payload".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Modify ciphertext
+		ciphertext[0] ^= 0xFF;
+
+		// Decrypt should fail
+		AesGcm decipher = new AesGcm(128);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] plaintext = new byte[payload.length];
+
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertFalse(valid, "Tag verification should fail when ciphertext is modified");
+	}
+
+	@Test
+	public void testMultiplePackets() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		AesGcm decipher = new AesGcm(128);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		// Send multiple packets
+		for (int i = 0; i < 100; i++) {
+			byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+			byte[] payload = ("Packet " + i).getBytes();
+			byte[] ciphertext = new byte[payload.length];
+			byte[] tag = new byte[16];
+			byte[] encryptedLength = new byte[4];
+
+			cipher.encryptPacketLength(i, plainLength, encryptedLength, 0);
+			cipher.seal(i, payload, ciphertext, tag, encryptedLength);
+
+			byte[] plaintext = new byte[payload.length];
+			boolean valid = decipher.open(i, ciphertext, tag, plaintext, encryptedLength);
+
+			assertTrue(valid, "Packet " + i + " should verify successfully");
+			assertArrayEquals(payload, plaintext, "Packet " + i + " plaintext should match");
+		}
+	}
+
+	@Test
+	public void testEmptyPayload() throws Exception {
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x00 };
+		byte[] payload = new byte[0];
+		byte[] ciphertext = new byte[0];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Decrypt
+		AesGcm decipher = new AesGcm(128);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] plaintext = new byte[0];
+
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertTrue(valid, "Tag verification should succeed for empty payload");
+	}
+
+	@Test
+	public void testLargePayload() throws Exception {
+		AesGcm cipher = new AesGcm(256);
+		byte[] keyMaterial = new byte[44];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		// Test with 32KB payload
+		byte[] payload = new byte[32768];
+		random.nextBytes(payload);
+
+		byte[] plainLength = { 0x00, 0x00, (byte) 0x80, 0x00 };
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Decrypt
+		AesGcm decipher = new AesGcm(256);
+		decipher.init(false, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		byte[] plaintext = new byte[payload.length];
+
+		boolean valid = decipher.open(1, ciphertext, tag, plaintext, encryptedLength);
+
+		assertTrue(valid, "Tag verification should succeed for large payload");
+		assertArrayEquals(payload, plaintext, "Large payload should match");
+	}
+
+	@Test
+	public void testInvalidKeySize() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			new AesGcm(192); // Only 128 and 256 are supported
+		});
+	}
+
+	@Test
+	public void testInvalidKeyMaterialLength128() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			AesGcm cipher = new AesGcm(128);
+			byte[] keyMaterial = new byte[27]; // Should be 28
+			cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+					Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		});
+	}
+
+	@Test
+	public void testInvalidKeyMaterialLength256() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			AesGcm cipher = new AesGcm(256);
+			byte[] keyMaterial = new byte[43]; // Should be 44
+			cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+					Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+		});
+	}
+
+	@Test
+	public void testGetKeySize() {
+		AesGcm cipher128 = new AesGcm(128);
+		assertEquals(16, cipher128.getKeySize());
+
+		AesGcm cipher256 = new AesGcm(256);
+		assertEquals(32, cipher256.getKeySize());
+	}
+
+	@Test
+	public void testGetTagSize() {
+		AesGcm cipher = new AesGcm(128);
+		assertEquals(16, cipher.getTagSize());
+	}
+
+	@Test
+	public void testLengthNotEncrypted() throws Exception {
+		// Verify that AES-GCM does NOT encrypt the length field
+		AesGcm cipher = new AesGcm(128);
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x01, 0x02, 0x03, 0x04 };
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+
+		// For AES-GCM, length should be copied as-is (not encrypted)
+		assertArrayEquals(plainLength, encryptedLength, "Length should not be encrypted for AES-GCM");
+	}
+
+	@Test
+	public void testInnerClassAES128() throws Exception {
+		AesGcm.AES128 cipher = new AesGcm.AES128();
+		assertEquals(16, cipher.getKeySize());
+
+		byte[] keyMaterial = new byte[28];
+		random.nextBytes(keyMaterial);
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Verify tag is generated
+		boolean allZeros = true;
+		for (byte b : tag) {
+			if (b != 0) {
+				allZeros = false;
+				break;
+			}
+		}
+		assertFalse(allZeros, "Tag should not be all zeros");
+	}
+
+	@Test
+	public void testInnerClassAES256() throws Exception {
+		AesGcm.AES256 cipher = new AesGcm.AES256();
+		assertEquals(32, cipher.getKeySize());
+
+		byte[] keyMaterial = new byte[44];
+		random.nextBytes(keyMaterial);
+		cipher.init(true, Arrays.copyOfRange(keyMaterial, 0, keyMaterial.length - 12),
+				Arrays.copyOfRange(keyMaterial, keyMaterial.length - 12, keyMaterial.length));
+
+		byte[] plainLength = { 0x00, 0x00, 0x00, 0x10 };
+		byte[] payload = "Test".getBytes();
+		byte[] ciphertext = new byte[payload.length];
+		byte[] tag = new byte[16];
+		byte[] encryptedLength = new byte[4];
+
+		cipher.encryptPacketLength(1, plainLength, encryptedLength, 0);
+		cipher.seal(1, payload, ciphertext, tag, encryptedLength);
+
+		// Verify tag is generated
+		boolean allZeros = true;
+		for (byte b : tag) {
+			if (b != 0) {
+				allZeros = false;
+				break;
+			}
+		}
+		assertFalse(allZeros, "Tag should not be all zeros");
+	}
+}

--- a/src/test/java/com/trilead/ssh2/crypto/cipher/ChaCha20Poly1305Test.java
+++ b/src/test/java/com/trilead/ssh2/crypto/cipher/ChaCha20Poly1305Test.java
@@ -69,7 +69,7 @@ public class ChaCha20Poly1305Test
 		};
 
 		ChaCha20Poly1305 cipher = new ChaCha20Poly1305();
-		cipher.init(true, keyMaterial);
+		cipher.init(true, keyMaterial, null);
 
 		// Test 1: Length encryption
 		byte[] plainLength = new byte[] { 0x00, 0x00, 0x00, 0x48 };
@@ -90,7 +90,7 @@ public class ChaCha20Poly1305Test
 
 		// Test 3: Decryption
 		ChaCha20Poly1305 decCipher = new ChaCha20Poly1305();
-		decCipher.init(false, keyMaterial);
+		decCipher.init(false, keyMaterial, null);
 
 		byte[] decryptedLength = new byte[4];
 		decCipher.decryptPacketLength(seqNum, encryptedLength, decryptedLength, 0);
@@ -115,10 +115,10 @@ public class ChaCha20Poly1305Test
 		}
 
 		ChaCha20Poly1305 encCipher = new ChaCha20Poly1305();
-		encCipher.init(true, key);
+		encCipher.init(true, key, null);
 
 		ChaCha20Poly1305 decCipher = new ChaCha20Poly1305();
-		decCipher.init(false, key);
+		decCipher.init(false, key, null);
 
 		byte[] plaintext = "Hello, ChaCha20-Poly1305!".getBytes();
 		byte[] lengthBytes = new byte[] { 0x00, 0x00, 0x00, 0x19 };
@@ -148,7 +148,7 @@ public class ChaCha20Poly1305Test
 	{
 		byte[] key = new byte[64];
 		ChaCha20Poly1305 cipher = new ChaCha20Poly1305();
-		cipher.init(false, key);
+		cipher.init(false, key, null);
 
 		byte[] ciphertext = new byte[32];
 		byte[] badTag = new byte[16]; // All zeros - invalid
@@ -170,10 +170,10 @@ public class ChaCha20Poly1305Test
 		}
 
 		ChaCha20Poly1305 encCipher = new ChaCha20Poly1305();
-		encCipher.init(true, key);
+		encCipher.init(true, key, null);
 
 		ChaCha20Poly1305 decCipher = new ChaCha20Poly1305();
-		decCipher.init(false, key);
+		decCipher.init(false, key, null);
 
 		byte[] plaintext = "Test message".getBytes();
 
@@ -202,10 +202,10 @@ public class ChaCha20Poly1305Test
 	{
 		byte[] key = new byte[64];
 		ChaCha20Poly1305 encCipher = new ChaCha20Poly1305();
-		encCipher.init(true, key);
+		encCipher.init(true, key, null);
 
 		ChaCha20Poly1305 decCipher = new ChaCha20Poly1305();
-		decCipher.init(false, key);
+		decCipher.init(false, key, null);
 
 		byte[] plaintext = "Test".getBytes();
 		byte[] lengthBytes = new byte[] { 0x00, 0x00, 0x00, 0x04 };


### PR DESCRIPTION
Added support for aes128-gcm\@openssh.com and aes256-gcm\@openssh.com AEAD ciphers per RFC 5647 and draft-miller-sshm-aes-gcm.