### PR TITLE
mlkem768x25519-sha256 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [17, 21]
+        java: [17, 21, 25]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up JDK ${{ matrix.java }}
@@ -29,13 +29,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build jacocoTestReport --info
+        run: ./gradlew build jacocoTestReport --info -PjdkVersion=${{ matrix.java }}
+        env:
+          SSH_TEST_REQUIRE_MLKEM: ${{ matrix.java >= 25 }}
       - name: Upload to Sonatype
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.java == '17'
         run: |
           echo "${{ secrets.MAVEN_GPG_PRIVATE_KEY }}" > ~/.gradle/secring.gpg.b64
           base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} -Psigning.keyId=${GPG_KEYID} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) -Psigning.password=${GPG_PASSWORD}
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -PjdkVersion=${{ matrix.java }} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} -Psigning.keyId=${GPG_KEYID} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg) -Psigning.password=${GPG_PASSWORD}
         env:
           GPG_KEYID: ${{ secrets.MAVEN_GPG_KEYID }}
           GPG_PASSWORD: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ https://opensource.org/licenses/BSD-3-Clause).
   * RSA  ([RFC 4253](https://tools.ietf.org/html/rfc4253#section-6.6))
 
 ##### Key exchange:
+  * mlkem768x25519-sha256 ([draft-ietf-sshm-mlkem-hybrid-kex](https://datatracker.ietf.org/doc/draft-ietf-sshm-mlkem-hybrid-kex/) (depends on JEP-496 support)
   * ecdh-sha2-nistp521 ([RFC 5656](https://tools.ietf.org/html/rfc5656#section-4))
   * ecdh-sha2-nistp384 ([RFC 5656](https://tools.ietf.org/html/rfc5656#section-4))
   * ecdh-sha2-nistp256 ([RFC 5656](https://tools.ietf.org/html/rfc5656#section-4))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,8 @@ java {
     withJavadocJar()
     withSourcesJar()
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        val jdkVersion = (project.findProperty("jdkVersion") as String?)?.toIntOrNull() ?: 11
+        languageVersion.set(JavaLanguageVersion.of(jdkVersion))
     }
 }
 

--- a/src/main/java/com/trilead/ssh2/crypto/KeyMaterial.java
+++ b/src/main/java/com/trilead/ssh2/crypto/KeyMaterial.java
@@ -2,8 +2,6 @@
 package com.trilead.ssh2.crypto;
 
 
-import java.math.BigInteger;
-
 import com.trilead.ssh2.crypto.digest.HashForSSH2Types;
 
 /**
@@ -21,7 +19,7 @@ public class KeyMaterial
 	public byte[] integrity_key_client_to_server;
 	public byte[] integrity_key_server_to_client;
 
-	private static byte[] calculateKey(HashForSSH2Types sh, BigInteger K, byte[] H, byte type, byte[] SessionID,
+	private static byte[] calculateKey(HashForSSH2Types sh, byte[] K, byte[] H, byte type, byte[] SessionID,
 			int keyLength)
 	{
 		byte[] res = new byte[keyLength];
@@ -36,7 +34,7 @@ public class KeyMaterial
 		byte[][] tmp = new byte[numRounds][];
 
 		sh.reset();
-		sh.updateBigInt(K);
+		sh.updateByteString(K);
 		sh.updateBytes(H);
 		sh.updateByte(type);
 		sh.updateBytes(SessionID);
@@ -53,7 +51,7 @@ public class KeyMaterial
 
 		for (int i = 1; i < numRounds; i++)
 		{
-			sh.updateBigInt(K);
+			sh.updateByteString(K);
 			sh.updateBytes(H);
 
 			for (int j = 0; j < i; j++)
@@ -70,7 +68,7 @@ public class KeyMaterial
 		return res;
 	}
 
-	public static KeyMaterial create(String hashAlgo, byte[] H, BigInteger K, byte[] SessionID, int keyLengthCS,
+	public static KeyMaterial create(String hashAlgo, byte[] H, byte[] K, byte[] SessionID, int keyLengthCS,
 			int blockSizeCS, int macLengthCS, int keyLengthSC, int blockSizeSC, int macLengthSC)
 			throws IllegalArgumentException
 	{

--- a/src/main/java/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/DhGroupExchange.java
@@ -60,14 +60,14 @@ public class DhGroupExchange
 	}
 
 	/**
-	 * @return Returns the shared secret k.
+	 * @return Returns the shared secret k as a byte array for key derivation.
 	 */
-	public BigInteger getK()
+	public byte[] getK()
 	{
 		if (k == null)
 			throw new IllegalStateException("Shared secret not yet known, need f first!");
 
-		return k;
+		return k.toByteArray();
 	}
 
 	/**
@@ -107,7 +107,7 @@ public class DhGroupExchange
 		hash.updateBigInt(g);
 		hash.updateBigInt(e);
 		hash.updateBigInt(f);
-		hash.updateBigInt(k);
+		hash.updateByteString(getK());
 
 		return hash.getDigest();
 	}

--- a/src/main/java/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
@@ -21,13 +21,16 @@ public abstract class GenericDhExchange
 
 	/* Shared secret */
 
-	BigInteger sharedSecret;
+	protected BigInteger sharedSecret;
 
 	protected GenericDhExchange()
 	{
 	}
 
 	public static GenericDhExchange getInstance(String algo) {
+		if (MlKemHybridExchange.NAME.equals(algo)) {
+			return new MlKemHybridExchange();
+		}
 		if (Curve25519Exchange.NAME.equals(algo) || Curve25519Exchange.ALT_NAME.equals(algo)) {
 			return new Curve25519Exchange();
 		}
@@ -53,15 +56,15 @@ public abstract class GenericDhExchange
 	protected abstract byte[] getServerE();
 
 	/**
-	 * @return Returns the shared secret k.
+	 * @return Returns the shared secret k as a byte array for key derivation.
 	 * @throws IllegalStateException if the shared secret is not available.
 	 */
-	public BigInteger getK()
+	public byte[] getK()
 	{
 		if (sharedSecret == null)
 			throw new IllegalStateException("Shared secret not yet known, need f first!");
 
-		return sharedSecret;
+		return sharedSecret.toByteArray();
 	}
 
 	/**
@@ -88,7 +91,7 @@ public abstract class GenericDhExchange
 		hash.updateByteString(hostKey);
 		hash.updateByteString(getE());
 		hash.updateByteString(getServerE());
-		hash.updateBigInt(sharedSecret);
+		hash.updateByteString(getK());
 
 		return hash.getDigest();
 	}

--- a/src/main/java/com/trilead/ssh2/crypto/dh/MlKemHybridExchange.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/MlKemHybridExchange.java
@@ -1,0 +1,226 @@
+package com.trilead.ssh2.crypto.dh;
+
+import com.google.crypto.tink.subtle.X25519;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+/**
+ * ML-KEM-768 hybrid key exchange implementation (mlkem768x25519-sha256).
+ * Combines post-quantum ML-KEM-768 with classical X25519 key exchange.
+ * Uses reflection to access Java 23+ KEM APIs while maintaining compatibility with Java 11+.
+ * Implements draft-ietf-sshm-mlkem-hybrid-kex-03 specification.
+ */
+public class MlKemHybridExchange extends GenericDhExchange {
+
+	public static final String NAME = "mlkem768x25519-sha256";
+	private static final int MLKEM768_PUBLIC_KEY_SIZE = 1184;
+	private static final int MLKEM768_CIPHERTEXT_SIZE = 1088;
+	private static final int MLKEM768_SHARED_SECRET_SIZE = 32;
+	private static final int X25519_KEY_SIZE = 32;
+
+	private byte[] mlkemPublicKey;
+	private byte[] mlkemPrivateKeyEncoded;
+	private byte[] x25519PublicKey;
+	private byte[] x25519PrivateKey;
+
+	private byte[] mlkemSharedSecret;
+	private byte[] x25519SharedSecret;
+	private byte[] serverX25519PublicKey;
+	private byte[] serverReply;
+	private byte[] hybridSharedSecretK;
+
+	private Object kemInstance;
+
+	public MlKemHybridExchange() {
+		super();
+	}
+
+	@Override
+	public void init(String name) throws IOException {
+		if (!NAME.equals(name)) {
+			throw new IOException("Invalid algorithm: " + name);
+		}
+
+		try {
+			KeyPairGenerator mlkemKpg = KeyPairGenerator.getInstance("ML-KEM-768");
+			KeyPair mlkemKeyPair = mlkemKpg.generateKeyPair();
+			byte[] x509Encoded = mlkemKeyPair.getPublic().getEncoded();
+			mlkemPublicKey = extractRawMlKemPublicKey(x509Encoded);
+			mlkemPrivateKeyEncoded = mlkemKeyPair.getPrivate().getEncoded();
+
+			if (mlkemPublicKey.length != MLKEM768_PUBLIC_KEY_SIZE) {
+				throw new IOException(
+						"Unexpected ML-KEM-768 public key size: "
+								+ mlkemPublicKey.length
+								+ " (expected "
+								+ MLKEM768_PUBLIC_KEY_SIZE
+								+ ")");
+			}
+
+			x25519PrivateKey = X25519.generatePrivateKey();
+			x25519PublicKey = X25519.publicFromPrivate(x25519PrivateKey);
+
+			if (x25519PublicKey.length != X25519_KEY_SIZE) {
+				throw new IOException(
+						"Unexpected X25519 public key size: "
+								+ x25519PublicKey.length
+								+ " (expected "
+								+ X25519_KEY_SIZE
+								+ ")");
+			}
+
+		} catch (NoSuchAlgorithmException e) {
+			throw new IOException("ML-KEM-768 or X25519 not available", e);
+		} catch (InvalidKeyException e) {
+			throw new IOException("Failed to generate key pair", e);
+		}
+	}
+
+	@Override
+	public byte[] getE() {
+		byte[] init = new byte[mlkemPublicKey.length + x25519PublicKey.length];
+		System.arraycopy(mlkemPublicKey, 0, init, 0, mlkemPublicKey.length);
+		System.arraycopy(
+				x25519PublicKey, 0, init, mlkemPublicKey.length, x25519PublicKey.length);
+		return init;
+	}
+
+	@Override
+	protected byte[] getServerE() {
+		return serverReply != null ? serverReply.clone() : new byte[0];
+	}
+
+	@Override
+	public void setF(byte[] f) throws IOException {
+		if (f.length != MLKEM768_CIPHERTEXT_SIZE + X25519_KEY_SIZE) {
+			throw new IOException(
+					"Invalid S_REPLY length: "
+							+ f.length
+							+ " (expected "
+							+ (MLKEM768_CIPHERTEXT_SIZE + X25519_KEY_SIZE)
+							+ ")");
+		}
+
+		serverReply = f.clone();
+
+		try {
+			byte[] mlkemCiphertext = new byte[MLKEM768_CIPHERTEXT_SIZE];
+			System.arraycopy(f, 0, mlkemCiphertext, 0, MLKEM768_CIPHERTEXT_SIZE);
+
+			serverX25519PublicKey = new byte[X25519_KEY_SIZE];
+			System.arraycopy(f, MLKEM768_CIPHERTEXT_SIZE, serverX25519PublicKey, 0, X25519_KEY_SIZE);
+
+			mlkemSharedSecret = performMlKemDecapsulation(mlkemCiphertext);
+
+			x25519SharedSecret = X25519.computeSharedSecret(x25519PrivateKey, serverX25519PublicKey);
+			validateX25519SharedSecret(x25519SharedSecret);
+
+			byte[] combined = new byte[MLKEM768_SHARED_SECRET_SIZE + X25519_KEY_SIZE];
+			System.arraycopy(mlkemSharedSecret, 0, combined, 0, MLKEM768_SHARED_SECRET_SIZE);
+			System.arraycopy(x25519SharedSecret, 0, combined, MLKEM768_SHARED_SECRET_SIZE, X25519_KEY_SIZE);
+
+			hybridSharedSecretK = computeHybridSharedSecret(combined);
+			sharedSecret = new BigInteger(1, hybridSharedSecretK);
+
+		} catch (InvalidKeyException e) {
+			throw new IOException("X25519 key agreement failed", e);
+		} catch (Exception e) {
+			throw new IOException("ML-KEM decapsulation or key agreement failed", e);
+		}
+	}
+
+	private byte[] performMlKemDecapsulation(byte[] ciphertext) throws IOException {
+		try {
+			if (kemInstance == null) {
+				Class<?> kemClass = Class.forName("javax.crypto.KEM");
+				Method getInstance = kemClass.getMethod("getInstance", String.class);
+				kemInstance = getInstance.invoke(null, "ML-KEM");
+			}
+
+			KeyFactory kf = KeyFactory.getInstance("ML-KEM");
+			PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(mlkemPrivateKeyEncoded);
+			PrivateKey mlkemPrivateKey = kf.generatePrivate(privateKeySpec);
+
+			Class<?> kemClass = Class.forName("javax.crypto.KEM");
+			Method newDecapsulator = kemClass.getMethod("newDecapsulator", PrivateKey.class);
+			Object decapsulator = newDecapsulator.invoke(kemInstance, mlkemPrivateKey);
+
+			Class<?> decapsulatorClass = Class.forName("javax.crypto.KEM$Decapsulator");
+			Method decapsulateMethod = decapsulatorClass.getMethod("decapsulate", byte[].class);
+			Object secretKey = decapsulateMethod.invoke(decapsulator, ciphertext);
+
+			javax.crypto.SecretKey sk = (javax.crypto.SecretKey) secretKey;
+			return sk.getEncoded();
+
+		} catch (ClassNotFoundException e) {
+			throw new IOException("ML-KEM not available (Java 23+ required)", e);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IOException("ML-KEM not available", e);
+		} catch (Exception e) {
+			throw new IOException("ML-KEM decapsulation failed", e);
+		}
+	}
+
+	private void validateX25519SharedSecret(byte[] sharedSecret) throws IOException {
+		int allBytes = 0;
+		for (int i = 0; i < sharedSecret.length; i++) {
+			allBytes |= sharedSecret[i];
+		}
+		if (allBytes == 0) {
+			throw new IOException("Invalid X25519 shared secret; all zeroes");
+		}
+	}
+
+	private byte[] computeHybridSharedSecret(byte[] combined) throws IOException {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			return md.digest(combined);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IOException("SHA-256 not available", e);
+		}
+	}
+
+	@Override
+	public String getHashAlgo() {
+		return "SHA-256";
+	}
+
+	@Override
+	public byte[] getK() {
+		if (hybridSharedSecretK == null) {
+			throw new IllegalStateException("Shared secret not yet known, need f first!");
+		}
+		return hybridSharedSecretK.clone();
+	}
+
+	private static byte[] extractRawMlKemPublicKey(byte[] x509Encoded) throws IOException {
+		if (x509Encoded.length < 22) {
+			throw new IOException("X.509 encoded ML-KEM public key too short");
+		}
+
+		if (x509Encoded[0] != 0x30) {
+			throw new IOException("Invalid X.509 encoding: expected SEQUENCE tag");
+		}
+
+		if (x509Encoded[17] != 0x03) {
+			throw new IOException("Invalid X.509 encoding: BIT STRING not found at expected position");
+		}
+
+		if (x509Encoded[21] != 0x00) {
+			throw new IOException("Invalid X.509 encoding: unexpected unused bits in BIT STRING");
+		}
+
+		byte[] rawKey = new byte[MLKEM768_PUBLIC_KEY_SIZE];
+		System.arraycopy(x509Encoded, 22, rawKey, 0, MLKEM768_PUBLIC_KEY_SIZE);
+		return rawKey;
+	}
+}

--- a/src/main/java/com/trilead/ssh2/transport/KexState.java
+++ b/src/main/java/com/trilead/ssh2/transport/KexState.java
@@ -1,8 +1,6 @@
 package com.trilead.ssh2.transport;
 
 
-import java.math.BigInteger;
-
 import com.trilead.ssh2.DHGexParameters;
 import com.trilead.ssh2.crypto.dh.DhGroupExchange;
 import com.trilead.ssh2.crypto.dh.GenericDhExchange;
@@ -21,7 +19,7 @@ public class KexState
 	public NegotiatedParameters np;
 	public int state = 0;
 
-	public BigInteger K;
+	public byte[] K;
 	public byte[] H;
 
 	public byte[] hostkey;

--- a/src/test/java/com/trilead/ssh2/DropbearCompatibilityTest.java
+++ b/src/test/java/com/trilead/ssh2/DropbearCompatibilityTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -213,6 +214,12 @@ public class DropbearCompatibilityTest {
 	@Test
 	public void canConnectWithKexEcdhSha2Nistp521() throws Exception {
 		assertCanConnectToServerWithKex("ecdh-sha2-nistp521");
+	}
+
+	@Test
+	public void canConnectWithKexMlKem768X25519() throws Exception {
+		Assumptions.assumeTrue(MlKemAvailability.isAvailable(), "ML-KEM not available on this JDK");
+		assertCanConnectToServerWithKex("mlkem768x25519-sha256");
 	}
 
 	private void setCiphers(Connection c, String cipher) {

--- a/src/test/java/com/trilead/ssh2/MlKemAvailability.java
+++ b/src/test/java/com/trilead/ssh2/MlKemAvailability.java
@@ -1,0 +1,64 @@
+package com.trilead.ssh2;
+
+/**
+ * Utility class for checking ML-KEM (JEP-496) availability.
+ *
+ * @author Kenny Root
+ */
+public final class MlKemAvailability {
+	private static final String REQUIRE_MLKEM_PROPERTY = "ssh.test.require.mlkem";
+	private static final String REQUIRE_MLKEM_ENV = "SSH_TEST_REQUIRE_MLKEM";
+
+	private MlKemAvailability() {
+	}
+
+	/**
+	 * Checks if ML-KEM-768 support is available in the current JDK.
+	 * This requires Java 23 or later with JEP-496 support.
+	 *
+	 * <p>If the system property "ssh.test.require.mlkem" or environment variable
+	 * "SSH_TEST_REQUIRE_MLKEM" is set to "true", this method will throw an
+	 * AssertionError if ML-KEM is not available. This is useful for CI environments
+	 * to ensure ML-KEM support is properly configured.
+	 *
+	 * @return true if ML-KEM is available, false otherwise
+	 * @throws AssertionError if ML-KEM is required but not available
+	 */
+	public static boolean isAvailable() {
+		boolean available = checkAvailability();
+		boolean required = isRequired();
+
+		if (required && !available) {
+			throw new AssertionError(
+					"ML-KEM support is required (via " + REQUIRE_MLKEM_PROPERTY
+							+ " or " + REQUIRE_MLKEM_ENV + ") but not available. "
+							+ "Ensure Java 23+ with JEP-496 support is being used.");
+		}
+
+		return available;
+	}
+
+	private static boolean checkAvailability() {
+		try {
+			Class.forName("javax.crypto.KEM");
+			java.security.KeyPairGenerator.getInstance("ML-KEM-768");
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private static boolean isRequired() {
+		String sysProp = System.getProperty(REQUIRE_MLKEM_PROPERTY);
+		if (sysProp != null) {
+			return Boolean.parseBoolean(sysProp);
+		}
+
+		String envVar = System.getenv(REQUIRE_MLKEM_ENV);
+		if (envVar != null) {
+			return Boolean.parseBoolean(envVar);
+		}
+
+		return false;
+	}
+}

--- a/src/test/java/com/trilead/ssh2/OpenSSHCompatibilityTest.java
+++ b/src/test/java/com/trilead/ssh2/OpenSSHCompatibilityTest.java
@@ -3,6 +3,7 @@ package com.trilead.ssh2;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -219,6 +220,12 @@ public class OpenSSHCompatibilityTest {
 	@Test
 	public void canConnectWithKexEcdhSha2Nistp521() throws Exception {
 		assertCanConnectToServerWithKex("ecdh-sha2-nistp521");
+	}
+
+	@Test
+	public void canConnectWithKexMlKem768X25519() throws Exception {
+		Assumptions.assumeTrue(MlKemAvailability.isAvailable(), "ML-KEM not available on this JDK");
+		assertCanConnectToServerWithKex("mlkem768x25519-sha256");
 	}
 
 	private void assertCanConnectToServerWithCipher(@NotNull String ciphers) throws IOException {

--- a/src/test/java/com/trilead/ssh2/crypto/dh/MlKemHybridExchangeTest.java
+++ b/src/test/java/com/trilead/ssh2/crypto/dh/MlKemHybridExchangeTest.java
@@ -1,0 +1,321 @@
+package com.trilead.ssh2.crypto.dh;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.trilead.ssh2.MlKemAvailability;
+
+@DisplayName("ML-KEM-768 Hybrid Key Exchange Tests")
+class MlKemHybridExchangeTest {
+
+	private static final boolean mlkemAvailable = MlKemAvailability.isAvailable();
+	private MlKemHybridExchange clientExchange;
+	private MlKemHybridExchange serverExchange;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		org.junit.jupiter.api.Assumptions.assumeTrue(
+				mlkemAvailable, "ML-KEM not available on this JDK");
+		clientExchange = new MlKemHybridExchange();
+		serverExchange = new MlKemHybridExchange();
+	}
+
+	@Test
+	@DisplayName("ML-KEM availability should be detected correctly")
+	void testMlKemAvailabilityDetection() {
+		System.out.println(
+				"ML-KEM availability: " + mlkemAvailable
+						+ " (expected true for Java 23 with proper ML-KEM support)");
+		assertTrue(
+				mlkemAvailable,
+				"ML-KEM should be available on Java 23 with proper configuration");
+	}
+
+	@Test
+	@DisplayName("Should initialize with correct algorithm name")
+	void testInitWithCorrectAlgorithm() throws IOException {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		assertNotNull(clientExchange.getE());
+	}
+
+	@Test
+	@DisplayName("Should reject invalid algorithm name")
+	void testInitWithInvalidAlgorithm() {
+		assertThrows(IOException.class, () -> clientExchange.init("invalid-algo"));
+	}
+
+	@Test
+	@DisplayName("Client should generate ephemeral public key")
+	void testClientPublicKeyGeneration() throws IOException {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		byte[] clientPublicKey = clientExchange.getE();
+
+		assertNotNull(clientPublicKey);
+		assertEquals(1216, clientPublicKey.length, "Client public key should be 1216 bytes (1184 ML-KEM + 32 X25519)");
+	}
+
+	@Test
+	@DisplayName("Server should extract client keys and perform encapsulation")
+	void testServerEncapsulation() throws Exception {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		serverExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] clientInit = clientExchange.getE();
+		byte[] mlkemPublicKey = new byte[1184];
+		byte[] x25519PublicKey = new byte[32];
+		System.arraycopy(clientInit, 0, mlkemPublicKey, 0, 1184);
+		System.arraycopy(clientInit, 1184, x25519PublicKey, 0, 32);
+
+		byte[] x509EncodedPublicKey = wrapRawMlKemPublicKey(mlkemPublicKey);
+		KeyFactory kf = KeyFactory.getInstance("ML-KEM");
+		X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(x509EncodedPublicKey);
+		PublicKey clientMlkemPublicKey = kf.generatePublic(publicKeySpec);
+
+		Class<?> kemClass = Class.forName("javax.crypto.KEM");
+		Method getInstance = kemClass.getMethod("getInstance", String.class);
+		Object kem = getInstance.invoke(null, "ML-KEM");
+
+		Method newEncapsulator = kemClass.getMethod("newEncapsulator", PublicKey.class);
+		Object encapsulator = newEncapsulator.invoke(kem, clientMlkemPublicKey);
+
+		Class<?> encapsulatorClass = Class.forName("javax.crypto.KEM$Encapsulator");
+		Method encapsulateMethod = encapsulatorClass.getMethod("encapsulate");
+		Object encapsulated = encapsulateMethod.invoke(encapsulator);
+
+		Class<?> encapsulatedClass = Class.forName("javax.crypto.KEM$Encapsulated");
+		Method encapsulationMethod = encapsulatedClass.getMethod("encapsulation");
+		byte[] ciphertext = (byte[]) encapsulationMethod.invoke(encapsulated);
+
+		assertEquals(1088, ciphertext.length, "ML-KEM-768 ciphertext should be 1088 bytes");
+	}
+
+	@Test
+	@DisplayName("Should compute hybrid shared secret from client and server exchange")
+	void testHybridKeyExchange() throws Exception {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		serverExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] clientInit = clientExchange.getE();
+		byte[] serverReply = performServerEncapsulation(clientInit, serverExchange.getE());
+
+		clientExchange.setF(serverReply);
+
+		byte[] clientK = clientExchange.getK();
+		assertNotNull(clientK);
+		assertEquals(32, clientK.length, "Shared secret should be 32 bytes");
+	}
+
+	@Test
+	@DisplayName("Client should reject invalid ciphertext length")
+	void testClientRejectsInvalidCiphertextLength() throws IOException {
+		clientExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] invalidReply = new byte[100];
+		assertThrows(IOException.class, () -> clientExchange.setF(invalidReply));
+	}
+
+	@Test
+	@DisplayName("Client should reject too long ciphertext")
+	void testClientRejectsTooLongCiphertext() throws IOException {
+		clientExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] invalidReply = new byte[2000];
+		assertThrows(IOException.class, () -> clientExchange.setF(invalidReply));
+	}
+
+	@Test
+	@DisplayName("Should return correct hash algorithm")
+	void testHashAlgorithm() throws IOException {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		assertEquals("SHA-256", clientExchange.getHashAlgo());
+	}
+
+	@Test
+	@DisplayName("Should calculate exchange hash correctly")
+	void testExchangeHashCalculation() throws Exception {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		serverExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] clientInit = clientExchange.getE();
+		byte[] serverReply = performServerEncapsulation(clientInit, serverExchange.getE());
+
+		clientExchange.setF(serverReply);
+
+		byte[] clientVersion = "SSH-2.0-Test".getBytes();
+		byte[] serverVersion = "SSH-2.0-TestServer".getBytes();
+		byte[] kexInit = new byte[20];
+		byte[] hostKey = new byte[100];
+
+		byte[] H =
+				clientExchange.calculateH(clientVersion, serverVersion, kexInit, kexInit, hostKey);
+
+		assertNotNull(H);
+		assertEquals(32, H.length, "SHA-256 hash should be 32 bytes");
+	}
+
+	@Test
+	@DisplayName("Two independent exchanges should produce different shared secrets")
+	void testDifferentExchangesProduceDifferentSecrets() throws Exception {
+		MlKemHybridExchange exchange1 = new MlKemHybridExchange();
+		MlKemHybridExchange exchange2 = new MlKemHybridExchange();
+
+		exchange1.init(MlKemHybridExchange.NAME);
+		exchange2.init(MlKemHybridExchange.NAME);
+
+		byte[] init1 = exchange1.getE();
+		byte[] init2 = exchange2.getE();
+
+		assertNotNull(init1);
+		assertNotNull(init2);
+		assertTrue(
+				!java.util.Arrays.equals(init1, init2),
+				"Two independent exchanges should produce different ephemeral keys");
+	}
+
+	@Test
+	@DisplayName("Shared secret should not be all zeros")
+	void testSharedSecretNotAllZeros() throws Exception {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		serverExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] clientInit = clientExchange.getE();
+		byte[] serverReply = performServerEncapsulation(clientInit, serverExchange.getE());
+
+		clientExchange.setF(serverReply);
+		byte[] K = clientExchange.getK();
+
+		int allZeros = 0;
+		for (byte b : K) {
+			allZeros |= b;
+		}
+		assertTrue(allZeros != 0, "Shared secret should not be all zeros");
+	}
+
+	@Test
+	@DisplayName("Should handle multiple sequential key exchanges")
+	void testMultipleSequentialExchanges() throws Exception {
+		for (int i = 0; i < 3; i++) {
+			MlKemHybridExchange client = new MlKemHybridExchange();
+			MlKemHybridExchange server = new MlKemHybridExchange();
+
+			client.init(MlKemHybridExchange.NAME);
+			server.init(MlKemHybridExchange.NAME);
+
+			byte[] clientInit = client.getE();
+			byte[] serverReply = performServerEncapsulation(clientInit, server.getE());
+
+			client.setF(serverReply);
+			byte[] K = client.getK();
+
+			assertNotNull(K);
+			assertEquals(32, K.length, "Exchange " + i + " should produce 32-byte shared secret");
+		}
+	}
+
+	@Test
+	@DisplayName("Client getServerE should return server reply")
+	void testGetServerE() throws Exception {
+		clientExchange.init(MlKemHybridExchange.NAME);
+		serverExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] clientInit = clientExchange.getE();
+		byte[] serverReply = performServerEncapsulation(clientInit, serverExchange.getE());
+
+		clientExchange.setF(serverReply);
+		byte[] serverE = clientExchange.getServerE();
+
+		assertNotNull(serverE);
+		assertEquals(1120, serverE.length, "Server E (S_REPLY) should be 1120 bytes (1088 ciphertext + 32 X25519 public key)");
+	}
+
+	@Test
+	@DisplayName("Should validate X25519 public key length")
+	void testX25519PublicKeyValidation() throws IOException {
+		clientExchange.init(MlKemHybridExchange.NAME);
+
+		byte[] validMlkemCiphertext = new byte[1088];
+		byte[] invalidX25519Key = new byte[16];
+
+		byte[] reply = new byte[1088 + 16];
+		System.arraycopy(validMlkemCiphertext, 0, reply, 0, 1088);
+		System.arraycopy(invalidX25519Key, 0, reply, 1088, 16);
+
+		assertThrows(IOException.class, () -> clientExchange.setF(reply));
+	}
+
+	private byte[] performServerEncapsulation(byte[] clientInit, byte[] serverPublicKey)
+			throws Exception {
+		byte[] mlkemPublicKey = new byte[1184];
+		byte[] x25519PublicKey = new byte[32];
+		System.arraycopy(clientInit, 0, mlkemPublicKey, 0, 1184);
+		System.arraycopy(clientInit, 1184, x25519PublicKey, 0, 32);
+
+		byte[] x509EncodedPublicKey = wrapRawMlKemPublicKey(mlkemPublicKey);
+		KeyFactory kf = KeyFactory.getInstance("ML-KEM");
+		X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(x509EncodedPublicKey);
+		PublicKey clientMlkemPublicKey = kf.generatePublic(publicKeySpec);
+
+		Class<?> kemClass = Class.forName("javax.crypto.KEM");
+		Method getInstance = kemClass.getMethod("getInstance", String.class);
+		Object kem = getInstance.invoke(null, "ML-KEM");
+
+		Method newEncapsulator = kemClass.getMethod("newEncapsulator", PublicKey.class);
+		Object encapsulator = newEncapsulator.invoke(kem, clientMlkemPublicKey);
+
+		Class<?> encapsulatorClass = Class.forName("javax.crypto.KEM$Encapsulator");
+		Method encapsulateMethod = encapsulatorClass.getMethod("encapsulate");
+		Object encapsulated = encapsulateMethod.invoke(encapsulator);
+
+		Class<?> encapsulatedClass = Class.forName("javax.crypto.KEM$Encapsulated");
+		Method encapsulationMethod = encapsulatedClass.getMethod("encapsulation");
+		byte[] ciphertext = (byte[]) encapsulationMethod.invoke(encapsulated);
+
+		byte[] serverX25519PublicKey = new byte[32];
+		System.arraycopy(serverPublicKey, 1184, serverX25519PublicKey, 0, 32);
+
+		byte[] reply = new byte[1088 + 32];
+		System.arraycopy(ciphertext, 0, reply, 0, 1088);
+		System.arraycopy(serverX25519PublicKey, 0, reply, 1088, 32);
+
+		return reply;
+	}
+
+	private byte[] wrapRawMlKemPublicKey(byte[] rawKey) {
+		byte[] x509 = new byte[1206];
+		x509[0] = 0x30;
+		x509[1] = (byte) 0x82;
+		x509[2] = 0x04;
+		x509[3] = (byte) 0xb2;
+		x509[4] = 0x30;
+		x509[5] = 0x0b;
+		x509[6] = 0x06;
+		x509[7] = 0x09;
+		x509[8] = 0x60;
+		x509[9] = (byte) 0x86;
+		x509[10] = 0x48;
+		x509[11] = 0x01;
+		x509[12] = 0x65;
+		x509[13] = 0x03;
+		x509[14] = 0x04;
+		x509[15] = 0x04;
+		x509[16] = 0x02;
+		x509[17] = 0x03;
+		x509[18] = (byte) 0x82;
+		x509[19] = 0x04;
+		x509[20] = (byte) 0xa1;
+		x509[21] = 0x00;
+		System.arraycopy(rawKey, 0, x509, 22, 1184);
+		return x509;
+	}
+}


### PR DESCRIPTION
Add support for hybrid key exchange method combining ML-KEM-768, a post-quantum crypto module-lattice-based key encapsulation method based on the Module Learning with Errors (M-LWE) problem, combined with X25519, a classical Curve25519 elliptic curve Diffie-Hellman exchange algorithm based on the Discrete Log Problem.

This is based on draft-ietf-sshm-mlkem-hybrid-kex-03.