### PR TITLE
Enable mlkem768x25519-sha256 on pre-Java 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build jacocoTestReport --info -PjdkVersion=${{ matrix.java }}
-        env:
-          SSH_TEST_REQUIRE_MLKEM: ${{ matrix.java >= 25 }}
       - name: Upload to Sonatype
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.java == '17'
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
         isTransitive = false
     }
     implementation("org.connectbot:jbcrypt:1.0.2")
+    implementation("asia.hombre:kyber:2.0.1")
 
     testImplementation("ch.qos.logback:logback-classic:1.5.21")
     testImplementation("commons-codec:commons-codec:1.19.0")
@@ -63,7 +64,7 @@ java {
     withJavadocJar()
     withSourcesJar()
     toolchain {
-        val jdkVersion = (project.findProperty("jdkVersion") as String?)?.toIntOrNull() ?: 11
+        val jdkVersion = (project.findProperty("jdkVersion") as String?)?.toIntOrNull() ?: 17
         languageVersion.set(JavaLanguageVersion.of(jdkVersion))
     }
 }

--- a/src/main/java/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/GenericDhExchange.java
@@ -29,7 +29,11 @@ public abstract class GenericDhExchange
 
 	public static GenericDhExchange getInstance(String algo) {
 		if (MlKemHybridExchange.NAME.equals(algo)) {
-			return new MlKemHybridExchange();
+			try {
+				return new MlKemHybridExchange();
+			} catch (IOException e) {
+				throw new RuntimeException("Failed to create ML-KEM hybrid exchange", e);
+			}
 		}
 		if (Curve25519Exchange.NAME.equals(algo) || Curve25519Exchange.ALT_NAME.equals(algo)) {
 			return new Curve25519Exchange();

--- a/src/main/java/com/trilead/ssh2/crypto/dh/JavaKemAdapter.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/JavaKemAdapter.java
@@ -1,0 +1,200 @@
+package com.trilead.ssh2.crypto.dh;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+/**
+ * ML-KEM adapter using Java 23+ native javax.crypto.KEM API.
+ * Uses reflection to maintain compatibility with Java 11+.
+ */
+public class JavaKemAdapter implements MlKemAdapter {
+
+	private static final int MLKEM768_PUBLIC_KEY_SIZE = 1184;
+	private static final int MLKEM768_CIPHERTEXT_SIZE = 1088;
+
+	private Object kemInstance;
+
+	public JavaKemAdapter() throws IOException {
+		try {
+			Class<?> kemClass = Class.forName("javax.crypto.KEM");
+			Method getInstance = kemClass.getMethod("getInstance", String.class);
+			kemInstance = getInstance.invoke(null, "ML-KEM");
+		} catch (Exception e) {
+			throw new IOException("Failed to initialize Java KEM API", e);
+		}
+	}
+
+	@Override
+	public MlKemKeyPair generateKeyPair() throws IOException {
+		try {
+			KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM-768");
+			KeyPair keyPair = kpg.generateKeyPair();
+
+			byte[] x509PublicKey = keyPair.getPublic().getEncoded();
+			byte[] pkcs8PrivateKey = keyPair.getPrivate().getEncoded();
+
+			byte[] rawPublicKey = extractRawMlKemPublicKey(x509PublicKey);
+
+			return new JavaKemKeyPair(rawPublicKey, pkcs8PrivateKey);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IOException("ML-KEM-768 not available", e);
+		}
+	}
+
+	@Override
+	public MlKemEncapsulationResult encapsulate(byte[] publicKey) throws IOException {
+		try {
+			byte[] x509EncodedPublicKey = wrapRawMlKemPublicKey(publicKey);
+			KeyFactory kf = KeyFactory.getInstance("ML-KEM");
+			java.security.spec.X509EncodedKeySpec publicKeySpec =
+					new java.security.spec.X509EncodedKeySpec(x509EncodedPublicKey);
+			java.security.PublicKey mlkemPublicKey = kf.generatePublic(publicKeySpec);
+
+			Class<?> kemClass = Class.forName("javax.crypto.KEM");
+			Method newEncapsulator = kemClass.getMethod("newEncapsulator", java.security.PublicKey.class);
+			Object encapsulator = newEncapsulator.invoke(kemInstance, mlkemPublicKey);
+
+			Class<?> encapsulatorClass = Class.forName("javax.crypto.KEM$Encapsulator");
+			Method encapsulateMethod = encapsulatorClass.getMethod("encapsulate");
+			Object encapsulated = encapsulateMethod.invoke(encapsulator);
+
+			Class<?> encapsulatedClass = Class.forName("javax.crypto.KEM$Encapsulated");
+			Method encapsulationMethod = encapsulatedClass.getMethod("encapsulation");
+			byte[] ciphertext = (byte[]) encapsulationMethod.invoke(encapsulated);
+
+			Method keyMethod = encapsulatedClass.getMethod("key");
+			javax.crypto.SecretKey secretKey = (javax.crypto.SecretKey) keyMethod.invoke(encapsulated);
+			byte[] sharedSecret = secretKey.getEncoded();
+
+			return new JavaKemEncapsulationResult(ciphertext, sharedSecret);
+
+		} catch (Exception e) {
+			throw new IOException("ML-KEM encapsulation failed", e);
+		}
+	}
+
+	@Override
+	public byte[] decapsulate(byte[] privateKey, byte[] ciphertext) throws IOException {
+		try {
+			KeyFactory kf = KeyFactory.getInstance("ML-KEM");
+			PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(privateKey);
+			PrivateKey mlkemPrivateKey = kf.generatePrivate(privateKeySpec);
+
+			Class<?> kemClass = Class.forName("javax.crypto.KEM");
+			Method newDecapsulator = kemClass.getMethod("newDecapsulator", PrivateKey.class);
+			Object decapsulator = newDecapsulator.invoke(kemInstance, mlkemPrivateKey);
+
+			Class<?> decapsulatorClass = Class.forName("javax.crypto.KEM$Decapsulator");
+			Method decapsulateMethod = decapsulatorClass.getMethod("decapsulate", byte[].class);
+			Object secretKey = decapsulateMethod.invoke(decapsulator, ciphertext);
+
+			javax.crypto.SecretKey sk = (javax.crypto.SecretKey) secretKey;
+			return sk.getEncoded();
+
+		} catch (Exception e) {
+			throw new IOException("ML-KEM decapsulation failed", e);
+		}
+	}
+
+	private static byte[] extractRawMlKemPublicKey(byte[] x509Encoded) throws IOException {
+		if (x509Encoded.length < 22) {
+			throw new IOException("X.509 encoded ML-KEM public key too short");
+		}
+
+		if (x509Encoded[0] != 0x30) {
+			throw new IOException("Invalid X.509 encoding: expected SEQUENCE tag");
+		}
+
+		if (x509Encoded[17] != 0x03) {
+			throw new IOException("Invalid X.509 encoding: BIT STRING not found at expected position");
+		}
+
+		if (x509Encoded[21] != 0x00) {
+			throw new IOException("Invalid X.509 encoding: unexpected unused bits in BIT STRING");
+		}
+
+		byte[] rawKey = new byte[MLKEM768_PUBLIC_KEY_SIZE];
+		System.arraycopy(x509Encoded, 22, rawKey, 0, MLKEM768_PUBLIC_KEY_SIZE);
+		return rawKey;
+	}
+
+	private static byte[] wrapRawMlKemPublicKey(byte[] rawKey) throws IOException {
+		if (rawKey.length != MLKEM768_PUBLIC_KEY_SIZE) {
+			throw new IOException("Invalid raw ML-KEM public key size: " + rawKey.length);
+		}
+
+		byte[] x509 = new byte[1206];
+		x509[0] = 0x30;
+		x509[1] = (byte) 0x82;
+		x509[2] = 0x04;
+		x509[3] = (byte) 0xb2;
+		x509[4] = 0x30;
+		x509[5] = 0x0b;
+		x509[6] = 0x06;
+		x509[7] = 0x09;
+		x509[8] = 0x60;
+		x509[9] = (byte) 0x86;
+		x509[10] = 0x48;
+		x509[11] = 0x01;
+		x509[12] = 0x65;
+		x509[13] = 0x03;
+		x509[14] = 0x04;
+		x509[15] = 0x04;
+		x509[16] = 0x02;
+		x509[17] = 0x03;
+		x509[18] = (byte) 0x82;
+		x509[19] = 0x04;
+		x509[20] = (byte) 0xa1;
+		x509[21] = 0x00;
+
+		System.arraycopy(rawKey, 0, x509, 22, MLKEM768_PUBLIC_KEY_SIZE);
+
+		return x509;
+	}
+
+	private static class JavaKemKeyPair implements MlKemKeyPair {
+		private final byte[] publicKey;
+		private final byte[] privateKey;
+
+		JavaKemKeyPair(byte[] publicKey, byte[] privateKey) {
+			this.publicKey = publicKey;
+			this.privateKey = privateKey;
+		}
+
+		@Override
+		public byte[] getPublicKey() {
+			return publicKey;
+		}
+
+		@Override
+		public byte[] getPrivateKey() {
+			return privateKey;
+		}
+	}
+
+	private static class JavaKemEncapsulationResult implements MlKemEncapsulationResult {
+		private final byte[] ciphertext;
+		private final byte[] sharedSecret;
+
+		JavaKemEncapsulationResult(byte[] ciphertext, byte[] sharedSecret) {
+			this.ciphertext = ciphertext;
+			this.sharedSecret = sharedSecret;
+		}
+
+		@Override
+		public byte[] getCiphertext() {
+			return ciphertext;
+		}
+
+		@Override
+		public byte[] getSharedSecret() {
+			return sharedSecret;
+		}
+	}
+}

--- a/src/main/java/com/trilead/ssh2/crypto/dh/KyberKotlinAdapter.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/KyberKotlinAdapter.java
@@ -1,0 +1,117 @@
+package com.trilead.ssh2.crypto.dh;
+
+import asia.hombre.kyber.KyberCipherText;
+import asia.hombre.kyber.KyberDecapsulationKey;
+import asia.hombre.kyber.KyberEncapsulationKey;
+import asia.hombre.kyber.KyberEncapsulationResult;
+import asia.hombre.kyber.KyberKEMKeyPair;
+import asia.hombre.kyber.KyberKeyGenerator;
+import asia.hombre.kyber.KyberParameter;
+import asia.hombre.kyber.exceptions.InvalidKyberKeyException;
+import asia.hombre.kyber.exceptions.UnsupportedKyberVariantException;
+import asia.hombre.kyber.interfaces.RandomProvider;
+import java.io.IOException;
+import java.security.SecureRandom;
+
+/**
+ * ML-KEM adapter using Kyber Kotlin library as a fallback.
+ * This implementation is used when Java 23+ native KEM API is not available (e.g., Android).
+ */
+public class KyberKotlinAdapter implements MlKemAdapter {
+
+	private static final SecureRandomProvider RANDOM_PROVIDER = new SecureRandomProvider();
+
+	@Override
+	public MlKemKeyPair generateKeyPair() throws IOException {
+		try {
+			KyberKEMKeyPair keyPair = KyberKeyGenerator.generate(KyberParameter.ML_KEM_768, RANDOM_PROVIDER);
+
+			byte[] publicKey = keyPair.getEncapsulationKey().getFullBytes();
+			byte[] privateKey = keyPair.getDecapsulationKey().getFullBytes();
+
+			return new KyberKotlinKeyPair(publicKey, privateKey);
+		} catch (Exception e) {
+			throw new IOException("Failed to generate Kyber key pair", e);
+		}
+	}
+
+	@Override
+	public MlKemEncapsulationResult encapsulate(byte[] publicKey) throws IOException {
+		try {
+			KyberEncapsulationKey encapsKey = KyberEncapsulationKey.fromBytes(publicKey);
+			KyberEncapsulationResult result = encapsKey.encapsulate(RANDOM_PROVIDER);
+
+			byte[] ciphertext = result.getCipherText().getFullBytes();
+			byte[] sharedSecret = result.getSharedSecretKey();
+
+			return new KyberKotlinEncapsulationResult(ciphertext, sharedSecret);
+		} catch (UnsupportedKyberVariantException | InvalidKyberKeyException e) {
+			throw new IOException("Kyber encapsulation failed", e);
+		}
+	}
+
+	@Override
+	public byte[] decapsulate(byte[] privateKey, byte[] ciphertext) throws IOException {
+		try {
+			KyberDecapsulationKey decapsKey = KyberDecapsulationKey.fromBytes(privateKey);
+			KyberCipherText cipherText = KyberCipherText.fromBytes(ciphertext);
+
+			return decapsKey.decapsulate(cipherText);
+		} catch (UnsupportedKyberVariantException | InvalidKyberKeyException e) {
+			throw new IOException("Kyber decapsulation failed", e);
+		}
+	}
+
+	private static class KyberKotlinKeyPair implements MlKemKeyPair {
+		private final byte[] publicKey;
+		private final byte[] privateKey;
+
+		KyberKotlinKeyPair(byte[] publicKey, byte[] privateKey) {
+			this.publicKey = publicKey;
+			this.privateKey = privateKey;
+		}
+
+		@Override
+		public byte[] getPublicKey() {
+			return publicKey;
+		}
+
+		@Override
+		public byte[] getPrivateKey() {
+			return privateKey;
+		}
+	}
+
+	private static class KyberKotlinEncapsulationResult implements MlKemEncapsulationResult {
+		private final byte[] ciphertext;
+		private final byte[] sharedSecret;
+
+		KyberKotlinEncapsulationResult(byte[] ciphertext, byte[] sharedSecret) {
+			this.ciphertext = ciphertext;
+			this.sharedSecret = sharedSecret;
+		}
+
+		@Override
+		public byte[] getCiphertext() {
+			return ciphertext;
+		}
+
+		@Override
+		public byte[] getSharedSecret() {
+			return sharedSecret;
+		}
+	}
+
+	private static class SecureRandomProvider implements RandomProvider {
+		private final SecureRandom secureRandom;
+
+		SecureRandomProvider() {
+			this.secureRandom = new SecureRandom();
+		}
+
+		@Override
+		public void fillWithRandom(byte[] bytes) {
+			secureRandom.nextBytes(bytes);
+		}
+	}
+}

--- a/src/main/java/com/trilead/ssh2/crypto/dh/MlKemAdapter.java
+++ b/src/main/java/com/trilead/ssh2/crypto/dh/MlKemAdapter.java
@@ -1,0 +1,53 @@
+package com.trilead.ssh2.crypto.dh;
+
+import java.io.IOException;
+
+/**
+ * Interface for ML-KEM-768 operations.
+ * Allows for multiple implementations (Java 23+ native KEM API or Kyber Kotlin fallback).
+ */
+public interface MlKemAdapter {
+
+	/**
+	 * Generate a new ML-KEM-768 key pair.
+	 *
+	 * @return the key pair
+	 * @throws IOException if key generation fails
+	 */
+	MlKemKeyPair generateKeyPair() throws IOException;
+
+	/**
+	 * Encapsulate a shared secret using the given public key.
+	 *
+	 * @param publicKey the ML-KEM-768 public key (1184 bytes)
+	 * @return the encapsulation result containing ciphertext and shared secret
+	 * @throws IOException if encapsulation fails
+	 */
+	MlKemEncapsulationResult encapsulate(byte[] publicKey) throws IOException;
+
+	/**
+	 * Decapsulate a shared secret using the given private key and ciphertext.
+	 *
+	 * @param privateKey the ML-KEM-768 private key
+	 * @param ciphertext the ML-KEM-768 ciphertext (1088 bytes)
+	 * @return the shared secret (32 bytes)
+	 * @throws IOException if decapsulation fails
+	 */
+	byte[] decapsulate(byte[] privateKey, byte[] ciphertext) throws IOException;
+
+	/**
+	 * Represents an ML-KEM key pair.
+	 */
+	interface MlKemKeyPair {
+		byte[] getPublicKey();
+		byte[] getPrivateKey();
+	}
+
+	/**
+	 * Represents an ML-KEM encapsulation.
+	 */
+	interface MlKemEncapsulationResult {
+		byte[] getCiphertext();
+		byte[] getSharedSecret();
+	}
+}

--- a/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -86,13 +86,26 @@ public class KexManager
 			mlkemSupported = true;
 			log.log(10, "ML-KEM-768 support detected (Java 23+, KEM API available)");
 		} catch (NoSuchAlgorithmException e) {
-			log.log(10, "ML-KEM-768 unavailable: algorithm not found (requires Java 23+)");
+			log.log(10, "ML-KEM-768 unavailable via Java KEM API, trying Kyber Kotlin fallback");
+			mlkemSupported = tryKyberKotlin();
 		} catch (ClassNotFoundException e) {
-			log.log(10, "ML-KEM-768 unavailable: KEM API not found (requires Java 23+, not on all Android versions)");
+			log.log(10, "ML-KEM-768 unavailable via Java KEM API (requires Java 23+), trying Kyber Kotlin fallback");
+			mlkemSupported = tryKyberKotlin();
 		} catch (Exception e) {
 			log.log(10, "ML-KEM-768 unavailable: " + e.getMessage());
 		}
 		supportsMlKem = mlkemSupported;
+	}
+
+	private static boolean tryKyberKotlin() {
+		try {
+			Class.forName("asia.hombre.kyber.KyberKeyGenerator");
+			log.log(10, "ML-KEM-768 support detected via Kyber Kotlin");
+			return true;
+		} catch (ClassNotFoundException e) {
+			log.log(10, "Kyber Kotlin not available, ML-KEM-768 disabled");
+			return false;
+		}
 	}
 
 	private static final Set<String> HOSTKEY_ALGS = new LinkedHashSet<>();


### PR DESCRIPTION
This is required for Android to support PQ key exchange. Conscrypt is not currently setup to work for ML-KEM presumably because you need new classes added in Java 23.