### PR TITLE
Add implementation of host key rotation

### DIFF
--- a/src/main/java/com/trilead/ssh2/packets/PacketGlobalHostkeys.java
+++ b/src/main/java/com/trilead/ssh2/packets/PacketGlobalHostkeys.java
@@ -1,0 +1,77 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2016 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.trilead.ssh2.packets;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PacketGlobalHostkeys implements the hostkeys-00@openssh.com packet specified in
+ * <a href="https://github.com/openssh/openssh-portable/blob/deb8d99ecba70b67f4af7880b11ca8768df9ec3a/PROTOCOL">OpenSSH documentation</a>.
+ *
+ * @author Kenny Root
+ */
+public class PacketGlobalHostkeys
+{
+	public static final String HOSTKEYS_STANDARD = "hostkeys";
+	public static final String HOSTKEYS_VENDOR = "hostkeys-00@openssh.com";
+
+	private final byte[] payload;
+	private final ArrayList<byte[]> hostKeys;
+	private final String requestName;
+
+	public PacketGlobalHostkeys(List<byte[]> hostKeys)
+	{
+		this.hostKeys = new ArrayList<>(hostKeys);
+		this.payload = null;
+		this.requestName = null;
+	}
+
+	public PacketGlobalHostkeys(byte[] data, int off, int len) throws IOException
+	{
+		this.payload = new byte[len];
+		System.arraycopy(data, off, this.payload, 0, len);
+
+		TypesReader tr = new TypesReader(data, off, len);
+
+		int packet_type = tr.readByte();
+
+		if (packet_type != Packets.SSH_MSG_GLOBAL_REQUEST)
+			throw new IOException("This is not a SSH_MSG_GLOBAL_REQUEST! (" + packet_type + ")");
+
+		this.requestName = tr.readString();
+
+		boolean wantReply = tr.readBoolean();
+
+		hostKeys = new ArrayList<byte[]>();
+		while (tr.remain() != 0) {
+			hostKeys.add(tr.readByteString());
+		}
+	}
+
+	public List<byte[]> getHostkeys()
+	{
+		return hostKeys;
+	}
+
+	public String getRequestName()
+	{
+		return requestName;
+	}
+}

--- a/src/main/java/com/trilead/ssh2/packets/PacketGlobalHostkeysProve.java
+++ b/src/main/java/com/trilead/ssh2/packets/PacketGlobalHostkeysProve.java
@@ -1,0 +1,116 @@
+/*
+ * ConnectBot: simple, powerful, open-source SSH client for Android
+ * Copyright 2016 Kenny Root
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.trilead.ssh2.packets;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PacketGlobalHostkeysProve implements the hostkeys-prove-00@openssh.com packet specified in
+ * <a href="https://github.com/openssh/openssh-portable/blob/deb8d99ecba70b67f4af7880b11ca8768df9ec3a/PROTOCOL">OpenSSH documentation</a>.
+ *
+ * @author Kenny Root
+ */
+public class PacketGlobalHostkeysProve
+{
+	public static final String HOSTKEYS_PROVE_STANDARD = "hostkeys-prove";
+	public static final String HOSTKEYS_PROVE_VENDOR = "hostkeys-prove-00@openssh.com";
+
+	private final byte[] payload;
+	private final ArrayList<byte[]> hostKeys;
+	private final ArrayList<byte[]> signatures;
+	private final String requestName;
+
+	public PacketGlobalHostkeysProve(String requestName, List<byte[]> hostKeys)
+	{
+		this.requestName = requestName;
+		this.hostKeys = new ArrayList<>(hostKeys);
+		this.payload = null;
+		this.signatures = null;
+	}
+
+	public PacketGlobalHostkeysProve(byte[] data, int off, int len, boolean isResponse) throws IOException
+	{
+		this.payload = new byte[len];
+		System.arraycopy(data, off, this.payload, 0, len);
+
+		TypesReader tr = new TypesReader(data, off, len);
+
+		int packet_type = tr.readByte();
+
+		if (isResponse) {
+			if (packet_type != Packets.SSH_MSG_REQUEST_SUCCESS)
+				throw new IOException("This is not a SSH_MSG_REQUEST_SUCCESS! (" + packet_type + ")");
+
+			this.signatures = new ArrayList<byte[]>();
+			while (tr.remain() != 0) {
+				signatures.add(tr.readByteString());
+			}
+
+			this.hostKeys = null;
+			this.requestName = null;
+		} else {
+			if (packet_type != Packets.SSH_MSG_GLOBAL_REQUEST)
+				throw new IOException("This is not a SSH_MSG_GLOBAL_REQUEST! (" + packet_type + ")");
+
+			this.requestName = tr.readString();
+			boolean wantReply = tr.readBoolean();
+
+			this.hostKeys = new ArrayList<byte[]>();
+			while (tr.remain() != 0) {
+				hostKeys.add(tr.readByteString());
+			}
+
+			this.signatures = null;
+		}
+	}
+
+	public byte[] getPayload()
+	{
+		if (requestName == null || hostKeys == null)
+			throw new IllegalStateException("Cannot generate payload from a response packet");
+
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString(requestName);
+		tw.writeBoolean(true);
+
+		for (byte[] hostKey : hostKeys) {
+			tw.writeString(hostKey, 0, hostKey.length);
+		}
+
+		return tw.getBytes();
+	}
+
+	public List<byte[]> getHostkeys()
+	{
+		return hostKeys;
+	}
+
+	public List<byte[]> getSignatures()
+	{
+		return signatures;
+	}
+
+	public String getRequestName()
+	{
+		return requestName;
+	}
+}

--- a/src/main/java/com/trilead/ssh2/transport/ITransportConnection.java
+++ b/src/main/java/com/trilead/ssh2/transport/ITransportConnection.java
@@ -2,6 +2,9 @@ package com.trilead.ssh2.transport;
 
 import java.io.IOException;
 
+import com.trilead.ssh2.ConnectionInfo;
+import com.trilead.ssh2.ServerHostKeyVerifier;
+
 /**
  * Interface for SSH transport layer operations.
  * <p>
@@ -64,4 +67,41 @@ public interface ITransportConnection {
 	 * @return the estimated overhead in bytes
 	 */
 	int getPacketOverheadEstimate();
+
+	/**
+	 * Get connection information for a given key exchange number.
+	 *
+	 * @param kexNumber the key exchange number
+	 * @return connection information
+	 * @throws IOException if an error occurs
+	 */
+	ConnectionInfo getConnectionInfo(int kexNumber) throws IOException;
+
+	/**
+	 * Get the session identifier from the initial key exchange.
+	 *
+	 * @return the session identifier
+	 */
+	byte[] getSessionIdentifier();
+
+	/**
+	 * Get the hostname of the remote server.
+	 *
+	 * @return the hostname
+	 */
+	String getHostname();
+
+	/**
+	 * Get the port of the remote server.
+	 *
+	 * @return the port number
+	 */
+	int getPort();
+
+	/**
+	 * Get the server host key verifier.
+	 *
+	 * @return the server host key verifier or null if not set
+	 */
+	ServerHostKeyVerifier getServerHostKeyVerifier();
 }

--- a/src/main/java/com/trilead/ssh2/transport/KexManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/KexManager.java
@@ -208,6 +208,11 @@ public class KexManager
 		}
 	}
 
+	public ServerHostKeyVerifier getServerHostKeyVerifier()
+	{
+		return verifier;
+	}
+
 	private String getFirstMatch(String[] client, String[] server) throws NegotiateException
 	{
 		if (client == null || server == null)

--- a/src/main/java/com/trilead/ssh2/transport/TransportManager.java
+++ b/src/main/java/com/trilead/ssh2/transport/TransportManager.java
@@ -175,6 +175,21 @@ public class TransportManager implements ITransportConnection
 		return km.sessionId;
 	}
 
+	public String getHostname()
+	{
+		return hostname;
+	}
+
+	public int getPort()
+	{
+		return port;
+	}
+
+	public ServerHostKeyVerifier getServerHostKeyVerifier()
+	{
+		return km != null ? km.getServerHostKeyVerifier() : null;
+	}
+
 	public void close(Throwable cause, boolean useDisconnectPacket)
 	{
 		if (!useDisconnectPacket)

--- a/src/test/java/com/trilead/ssh2/channel/ChannelManagerTest.java
+++ b/src/test/java/com/trilead/ssh2/channel/ChannelManagerTest.java
@@ -412,8 +412,9 @@ public class ChannelManagerTest {
 	}
 
 	@Test
-	public void testMsgGlobalSuccess() {
-		channelManager.msgGlobalSuccess();
+	public void testMsgGlobalSuccess() throws Exception {
+		byte[] msg = new byte[]{(byte) Packets.SSH_MSG_REQUEST_SUCCESS};
+		channelManager.msgGlobalSuccess(msg, 1);
 		// Just verify it doesn't throw
 		// The internal state change can't be easily tested without reflection
 	}

--- a/src/test/java/com/trilead/ssh2/packets/PacketGlobalHostkeysProveTest.java
+++ b/src/test/java/com/trilead/ssh2/packets/PacketGlobalHostkeysProveTest.java
@@ -1,0 +1,147 @@
+package com.trilead.ssh2.packets;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PacketGlobalHostkeysProveTest {
+
+	@Test
+	public void createRequest_Success() throws Exception {
+		byte[] key1 = new byte[] { 0x01, 0x02, 0x03 };
+		byte[] key2 = new byte[] { 0x04, 0x05 };
+
+		PacketGlobalHostkeysProve packet = new PacketGlobalHostkeysProve(
+			PacketGlobalHostkeysProve.HOSTKEYS_PROVE_VENDOR,
+			Arrays.asList(key1, key2)
+		);
+
+		byte[] payload = packet.getPayload();
+		TypesReader tr = new TypesReader(payload);
+
+		assertThat(tr.readByte(), equalTo(Packets.SSH_MSG_GLOBAL_REQUEST));
+		assertThat(tr.readString(), equalTo(PacketGlobalHostkeysProve.HOSTKEYS_PROVE_VENDOR));
+		assertThat(tr.readBoolean(), equalTo(true));
+		assertThat(tr.readByteString(), equalTo(key1));
+		assertThat(tr.readByteString(), equalTo(key2));
+		assertThat(tr.remain(), equalTo(0));
+	}
+
+	@Test
+	public void createRequestStandard_Success() throws Exception {
+		byte[] key1 = new byte[] { 0x01, 0x02 };
+
+		PacketGlobalHostkeysProve packet = new PacketGlobalHostkeysProve(
+			PacketGlobalHostkeysProve.HOSTKEYS_PROVE_STANDARD,
+			Arrays.asList(key1)
+		);
+
+		byte[] payload = packet.getPayload();
+		TypesReader tr = new TypesReader(payload);
+
+		assertThat(tr.readByte(), equalTo(Packets.SSH_MSG_GLOBAL_REQUEST));
+		assertThat(tr.readString(), equalTo(PacketGlobalHostkeysProve.HOSTKEYS_PROVE_STANDARD));
+		assertThat(tr.readBoolean(), equalTo(true));
+	}
+
+	@Test
+	public void parseResponse_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_REQUEST_SUCCESS);
+		tw.writeString(new byte[] { 0x01, 0x02, 0x03 }, 0, 3);
+		tw.writeString(new byte[] { 0x04, 0x05 }, 0, 2);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeysProve packet = new PacketGlobalHostkeysProve(data, 0, data.length, true);
+
+		assertThat(packet.getSignatures(), hasSize(2));
+		assertThat(packet.getSignatures().get(0), equalTo(new byte[] { 0x01, 0x02, 0x03 }));
+		assertThat(packet.getSignatures().get(1), equalTo(new byte[] { 0x04, 0x05 }));
+	}
+
+	@Test
+	public void parseRequest_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString(PacketGlobalHostkeysProve.HOSTKEYS_PROVE_VENDOR);
+		tw.writeBoolean(true);
+		tw.writeString(new byte[] { 0x01, 0x02 }, 0, 2);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeysProve packet = new PacketGlobalHostkeysProve(data, 0, data.length, false);
+
+		assertThat(packet.getRequestName(), equalTo(PacketGlobalHostkeysProve.HOSTKEYS_PROVE_VENDOR));
+		assertThat(packet.getHostkeys(), hasSize(1));
+		assertThat(packet.getHostkeys().get(0), equalTo(new byte[] { 0x01, 0x02 }));
+	}
+
+	@Test
+	public void parseResponseWrongType_Failure() {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_REQUEST_FAILURE);
+
+		byte[] data = tw.getBytes();
+		assertThrows(IOException.class, () -> {
+			new PacketGlobalHostkeysProve(data, 0, data.length, true);
+		});
+	}
+
+	@Test
+	public void parseRequestWrongType_Failure() {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_REQUEST_SUCCESS);
+
+		byte[] data = tw.getBytes();
+		assertThrows(IOException.class, () -> {
+			new PacketGlobalHostkeysProve(data, 0, data.length, false);
+		});
+	}
+
+	@Test
+	public void getPayloadFromResponse_Failure() {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_REQUEST_SUCCESS);
+		tw.writeString(new byte[] { 0x01 }, 0, 1);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeysProve packet;
+		try {
+			packet = new PacketGlobalHostkeysProve(data, 0, data.length, true);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+		PacketGlobalHostkeysProve finalPacket = packet;
+		assertThrows(IllegalStateException.class, () -> {
+			finalPacket.getPayload();
+		});
+	}
+
+	@Test
+	public void parseMultipleSignatures_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_REQUEST_SUCCESS);
+
+		for (int i = 0; i < 5; i++) {
+			byte[] sig = new byte[i + 1];
+			Arrays.fill(sig, (byte) i);
+			tw.writeString(sig, 0, sig.length);
+		}
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeysProve packet = new PacketGlobalHostkeysProve(data, 0, data.length, true);
+
+		assertThat(packet.getSignatures(), hasSize(5));
+		for (int i = 0; i < 5; i++) {
+			byte[] expected = new byte[i + 1];
+			Arrays.fill(expected, (byte) i);
+			assertThat(packet.getSignatures().get(i), equalTo(expected));
+		}
+	}
+}

--- a/src/test/java/com/trilead/ssh2/packets/PacketGlobalHostkeysTest.java
+++ b/src/test/java/com/trilead/ssh2/packets/PacketGlobalHostkeysTest.java
@@ -1,0 +1,113 @@
+package com.trilead.ssh2.packets;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PacketGlobalHostkeysTest {
+
+	@Test
+	public void parseVendorName_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString("hostkeys-00@openssh.com");
+		tw.writeBoolean(false);
+		tw.writeString(new byte[] { 0x01, 0x02, 0x03 }, 0, 3);
+		tw.writeString(new byte[] { 0x04, 0x05 }, 0, 2);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeys packet = new PacketGlobalHostkeys(data, 0, data.length);
+
+		assertThat(packet.getRequestName(), equalTo("hostkeys-00@openssh.com"));
+		assertThat(packet.getHostkeys(), hasSize(2));
+		assertThat(packet.getHostkeys().get(0), equalTo(new byte[] { 0x01, 0x02, 0x03 }));
+		assertThat(packet.getHostkeys().get(1), equalTo(new byte[] { 0x04, 0x05 }));
+	}
+
+	@Test
+	public void parseStandardName_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString("hostkeys");
+		tw.writeBoolean(false);
+		tw.writeString(new byte[] { 0x01, 0x02, 0x03 }, 0, 3);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeys packet = new PacketGlobalHostkeys(data, 0, data.length);
+
+		assertThat(packet.getRequestName(), equalTo("hostkeys"));
+		assertThat(packet.getHostkeys(), hasSize(1));
+	}
+
+	@Test
+	public void parseEmpty_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString("hostkeys-00@openssh.com");
+		tw.writeBoolean(false);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeys packet = new PacketGlobalHostkeys(data, 0, data.length);
+
+		assertThat(packet.getHostkeys(), hasSize(0));
+	}
+
+	@Test
+	public void parseWrongMessageType_Failure() {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_REQUEST_SUCCESS);
+		tw.writeString("hostkeys-00@openssh.com");
+
+		byte[] data = tw.getBytes();
+		assertThrows(IOException.class, () -> {
+			new PacketGlobalHostkeys(data, 0, data.length);
+		});
+	}
+
+	@Test
+	public void parseWithOffset_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(0xFF);
+		tw.writeByte(0xFF);
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString("hostkeys-00@openssh.com");
+		tw.writeBoolean(false);
+		tw.writeString(new byte[] { 0x01, 0x02 }, 0, 2);
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeys packet = new PacketGlobalHostkeys(data, 2, data.length - 2);
+
+		assertThat(packet.getHostkeys(), hasSize(1));
+		assertThat(packet.getHostkeys().get(0), equalTo(new byte[] { 0x01, 0x02 }));
+	}
+
+	@Test
+	public void parseMultipleKeys_Success() throws Exception {
+		TypesWriter tw = new TypesWriter();
+		tw.writeByte(Packets.SSH_MSG_GLOBAL_REQUEST);
+		tw.writeString("hostkeys-00@openssh.com");
+		tw.writeBoolean(false);
+
+		for (int i = 0; i < 5; i++) {
+			byte[] key = new byte[i + 1];
+			Arrays.fill(key, (byte) i);
+			tw.writeString(key, 0, key.length);
+		}
+
+		byte[] data = tw.getBytes();
+		PacketGlobalHostkeys packet = new PacketGlobalHostkeys(data, 0, data.length);
+
+		assertThat(packet.getHostkeys(), hasSize(5));
+		for (int i = 0; i < 5; i++) {
+			byte[] expected = new byte[i + 1];
+			Arrays.fill(expected, (byte) i);
+			assertThat(packet.getHostkeys().get(i), equalTo(expected));
+		}
+	}
+}


### PR DESCRIPTION
This is based on OpenSSH's original hostkeys-00@openssh.com protocol for rotating keys. It allows anyone using ExtendedHostKeyVerifier to add keys for a host and remove keys that are obsolete.

Fixes #12