### PR TITLE
Change DH group size based on security level

### DIFF
--- a/src/main/java/com/trilead/ssh2/DHGexParameters.java
+++ b/src/main/java/com/trilead/ssh2/DHGexParameters.java
@@ -24,13 +24,39 @@ public class DHGexParameters
 	private static final int MAX_ALLOWED = 8192;
 
 	/**
-	 * Same as calling {@link #DHGexParameters(int, int, int) DHGexParameters(1024, 1024, 4096)}.
+	 * Same as calling {@link #DHGexParameters(int, int, int) DHGexParameters(1024, 2048, 8192)}.
 	 * This is also the default used by the Connection class.
 	 *
 	 */
 	public DHGexParameters()
 	{
-		this(1024, 1024, 4096);
+		this(1024, 2048, 8192);
+	}
+
+	/**
+	 * Estimates the group order for a Diffie-Hellman group that has an
+	 * attack complexity approximately the same as O(2**bits).
+	 * Values from NIST Special Publication 800-57: Recommendation for Key
+	 * Management Part 1 (rev 3) limited by the recommended maximum value
+	 * from RFC4419 section 3.
+	 *
+	 * @param bits the estimated number of bits of security required
+	 * @return a DHGexParameters object with the estimated parameters
+	 */
+	public static DHGexParameters estimate(int bits) {
+		int min = 2048;
+		int pref = 8192;
+		int max = 8192;
+
+		if (bits <= 112) {
+			pref = 2048;
+		} else if (bits <= 128) {
+			pref = 3072;
+		} else if (bits <= 192) {
+			pref = 7680;
+		}
+
+		return new DHGexParameters(min, pref, max);
 	}
 
 	/**

--- a/src/test/java/com/trilead/ssh2/DHGexParametersTest.java
+++ b/src/test/java/com/trilead/ssh2/DHGexParametersTest.java
@@ -17,8 +17,8 @@ public class DHGexParametersTest {
 
 		// Default values should be 1024, 1024, 4096
 		assertEquals(1024, params.getMin_group_len(), "Default min group length should be 1024");
-		assertEquals(1024, params.getPref_group_len(), "Default preferred group length should be 1024");
-		assertEquals(4096, params.getMax_group_len(), "Default max group length should be 4096");
+		assertEquals(2048, params.getPref_group_len(), "Default preferred group length should be 2048");
+		assertEquals(8192, params.getMax_group_len(), "Default max group length should be 8192");
 	}
 
 	@Test


### PR DESCRIPTION
This is inspired by OpenSSH's way of determining DH Group Exchange group size by looking at all the other parameters involved and generating the group based on that.

Fixes #424