### PR TITLE
Fix upgrades for RSA hostkeys

### DIFF
--- a/src/main/java/com/trilead/ssh2/KnownHosts.java
+++ b/src/main/java/com/trilead/ssh2/KnownHosts.java
@@ -899,9 +899,13 @@ public class KnownHosts extends ExtendedServerHostKeyVerifier
 		List<String> algorithms = new ArrayList<>();
 
 		for (PublicKey key : keys) {
-			String algo = publicKeyToAlgorithm(key);
-			if (algo != null && !algorithms.contains(algo)) {
-				algorithms.add(algo);
+			if (key instanceof RSAPublicKey) {
+				algorithms.addAll(Arrays.asList(ALGOS_FOR_RSA));
+			} else {
+				String algo = publicKeyToAlgorithm(key);
+				if (algo != null && !algorithms.contains(algo)) {
+					algorithms.add(algo);
+				}
 			}
 		}
 


### PR DESCRIPTION
Since we support the ssh-rsa, rsa-sha-256, and rsa-sha-512, we need to add all of those algorithms to the list of supported algorithms when we have an RSA key.

Also add a test that checks RSA to Ed25519 upgrades.