### PR TITLE
Optimize BlockCipher throughput

### DIFF
--- a/src/main/java/com/trilead/ssh2/crypto/cipher/AES.java
+++ b/src/main/java/com/trilead/ssh2/crypto/cipher/AES.java
@@ -44,6 +44,15 @@ public abstract class AES implements BlockCipher
 		}
 	}
 
+	@Override
+	public void transformBlocks(byte[] src, int srcoff, byte[] dst, int dstoff, int numBlocks) {
+		try {
+			cipher.update(src, srcoff, numBlocks * AES_BLOCK_SIZE, dst, dstoff);
+		} catch (ShortBufferException e) {
+			throw new AssertionError(e);
+		}
+	}
+
 	/**
 	 * AES in CBC (Cipher Block Chaining) mode for SSH.
 	 */

--- a/src/main/java/com/trilead/ssh2/crypto/cipher/BlockCipher.java
+++ b/src/main/java/com/trilead/ssh2/crypto/cipher/BlockCipher.java
@@ -13,4 +13,11 @@ public interface BlockCipher
 	int getBlockSize();
 
 	void transformBlock(byte[] src, int srcoff, byte[] dst, int dstoff);
+
+	default void transformBlocks(byte[] src, int srcoff, byte[] dst, int dstoff, int numBlocks) {
+		int blockSize = getBlockSize();
+		for (int i = 0; i < numBlocks; i++) {
+			transformBlock(src, srcoff + i * blockSize, dst, dstoff + i * blockSize);
+		}
+	}
 }


### PR DESCRIPTION
This allows just a single JCE call for multiple blocks which should help with optimizing AES throughput. There might still be gains to be had with window optimization.

On the desktop benchmark test, this increases the throughput by 5x with 32KiB blocks.

Helps with https://github.com/connectbot/connectbot/issues/1544