### PR TITLE
Catch null in calls to KnownHosts

### DIFF
--- a/src/main/java/com/trilead/ssh2/KnownHosts.java
+++ b/src/main/java/com/trilead/ssh2/KnownHosts.java
@@ -368,6 +368,9 @@ public class KnownHosts extends ExtendedServerHostKeyVerifier
 		boolean isMatch = false;
 		boolean negate = false;
 
+		if (hostname == null)
+			return false;
+
 		hostname = hostname.toLowerCase(Locale.US);
 
 		for (int k = 0; k < hostpatterns.length; k++)
@@ -804,6 +807,9 @@ public class KnownHosts extends ExtendedServerHostKeyVerifier
 		synchronized (publicKeys) {
 			publicKeys.removeIf(entry -> {
 				if (!hostnameMatches(entry.patterns, hostname))
+					return false;
+
+				if (serverHostKeyAlgorithm == null)
 					return false;
 
 				String algo = publicKeyToAlgorithm(entry.key);

--- a/src/test/java/com/trilead/ssh2/KnownHostsTest.java
+++ b/src/test/java/com/trilead/ssh2/KnownHostsTest.java
@@ -153,4 +153,25 @@ public class KnownHostsTest {
 		assertThat(obj.getPreferredServerHostkeyAlgorithmOrder("unknown"),
 			nullValue());
 	}
+
+	@Test
+	public void removeServerHostKey_NullHostname() throws Exception {
+		KnownHosts obj = new KnownHosts();
+		obj.addHostkeys(getKnownHosts("known_hosts"));
+		obj.removeServerHostKey(null, 22, "ssh-rsa", null);
+	}
+
+	@Test
+	public void removeServerHostKey_NullAlgorithm() throws Exception {
+		KnownHosts obj = new KnownHosts();
+		obj.addHostkeys(getKnownHosts("known_hosts"));
+		obj.removeServerHostKey("example.com", 22, null, null);
+	}
+
+	@Test
+	public void removeServerHostKey_BothNull() throws Exception {
+		KnownHosts obj = new KnownHosts();
+		obj.addHostkeys(getKnownHosts("known_hosts"));
+		obj.removeServerHostKey(null, 22, null, null);
+	}
 }


### PR DESCRIPTION
If you pass null to some APIs, it could crash with NPE.