### PR TITLE
Fix key export for non-CRT RSA keys and add Ed25519 PEM support

### DIFF
--- a/src/main/java/com/trilead/ssh2/crypto/OpenSSHKeyEncoder.java
+++ b/src/main/java/com/trilead/ssh2/crypto/OpenSSHKeyEncoder.java
@@ -648,6 +648,15 @@ public class OpenSSHKeyEncoder {
 			throws InvalidKeyException {
 		if (privateKey instanceof RSAPrivateCrtKey && publicKey instanceof RSAPublicKey) {
 			return exportOpenSSHRSA((RSAPrivateCrtKey) privateKey, (RSAPublicKey) publicKey, comment, passphrase);
+		} else if (privateKey instanceof java.security.interfaces.RSAPrivateKey && publicKey instanceof RSAPublicKey) {
+			// Handle non-CRT RSA keys (e.g., from Conscrypt's OpenSSLRSAPrivateKey)
+			try {
+				RSAPrivateCrtKey crtKey = convertToRSAPrivateCrtKey(
+						(java.security.interfaces.RSAPrivateKey) privateKey);
+				return exportOpenSSHRSA(crtKey, (RSAPublicKey) publicKey, comment, passphrase);
+			} catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+				throw new InvalidKeyException("Failed to convert RSA key to CRT format", e);
+			}
 		} else if (privateKey instanceof DSAPrivateKey && publicKey instanceof DSAPublicKey) {
 			return exportOpenSSHDSA((DSAPrivateKey) privateKey, (DSAPublicKey) publicKey, comment, passphrase);
 		} else if (privateKey instanceof ECPrivateKey && publicKey instanceof ECPublicKey) {
@@ -658,6 +667,53 @@ public class OpenSSHKeyEncoder {
 		}
 		throw new InvalidKeyException(
 				"Unsupported key type: " + privateKey.getClass().getName() + " / " + publicKey.getClass().getName());
+	}
+
+	/**
+	 * Converts an RSAPrivateKey to RSAPrivateCrtKey by parsing the PKCS#8 encoded form.
+	 * This is needed for keys from providers like Conscrypt that don't implement RSAPrivateCrtKey.
+	 *
+	 * @param privateKey The RSA private key to convert
+	 * @return The RSAPrivateCrtKey with CRT parameters
+	 * @throws InvalidKeySpecException if the key cannot be parsed
+	 * @throws NoSuchAlgorithmException if RSA algorithm is not available
+	 */
+	private static RSAPrivateCrtKey convertToRSAPrivateCrtKey(java.security.interfaces.RSAPrivateKey privateKey)
+			throws InvalidKeySpecException, NoSuchAlgorithmException {
+		byte[] encoded = privateKey.getEncoded();
+		try {
+			SimpleDERReader reader = new SimpleDERReader(encoded);
+			reader.resetInput(reader.readSequenceAsByteArray());
+			if (!reader.readInt().equals(BigInteger.ZERO)) {
+				throw new InvalidKeySpecException("PKCS#8 is not version 0");
+			}
+
+			reader.readSequenceAsByteArray(); // OID sequence
+			reader.resetInput(reader.readOctetString()); // RSA key bytes
+			reader.resetInput(reader.readSequenceAsByteArray()); // RSA key sequence
+
+			if (!reader.readInt().equals(BigInteger.ZERO)) {
+				throw new InvalidKeySpecException("RSA key is not version 0");
+			}
+
+			BigInteger modulus = reader.readInt();
+			BigInteger publicExponent = reader.readInt();
+			BigInteger privateExponent = reader.readInt();
+			BigInteger primeP = reader.readInt();
+			BigInteger primeQ = reader.readInt();
+			BigInteger primeExponentP = reader.readInt();
+			BigInteger primeExponentQ = reader.readInt();
+			BigInteger crtCoefficient = reader.readInt();
+
+			java.security.spec.RSAPrivateCrtKeySpec spec = new java.security.spec.RSAPrivateCrtKeySpec(
+					modulus, publicExponent, privateExponent,
+					primeP, primeQ, primeExponentP, primeExponentQ, crtCoefficient);
+
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			return (RSAPrivateCrtKey) kf.generatePrivate(spec);
+		} catch (IOException e) {
+			throw new InvalidKeySpecException("Could not parse RSA key", e);
+		}
 	}
 
 	/**

--- a/src/main/java/com/trilead/ssh2/crypto/OpenSSHKeyEncoder.java
+++ b/src/main/java/com/trilead/ssh2/crypto/OpenSSHKeyEncoder.java
@@ -34,6 +34,7 @@ import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECPoint;
 import java.security.spec.InvalidKeySpecException;
@@ -648,11 +649,10 @@ public class OpenSSHKeyEncoder {
 			throws InvalidKeyException {
 		if (privateKey instanceof RSAPrivateCrtKey && publicKey instanceof RSAPublicKey) {
 			return exportOpenSSHRSA((RSAPrivateCrtKey) privateKey, (RSAPublicKey) publicKey, comment, passphrase);
-		} else if (privateKey instanceof java.security.interfaces.RSAPrivateKey && publicKey instanceof RSAPublicKey) {
+		} else if (privateKey instanceof RSAPrivateKey && publicKey instanceof RSAPublicKey) {
 			// Handle non-CRT RSA keys (e.g., from Conscrypt's OpenSSLRSAPrivateKey)
 			try {
-				RSAPrivateCrtKey crtKey = PEMEncoder.convertToRSAPrivateCrtKey(
-						(java.security.interfaces.RSAPrivateKey) privateKey);
+				RSAPrivateCrtKey crtKey = PEMEncoder.convertToRSAPrivateCrtKey((RSAPrivateKey) privateKey);
 				return exportOpenSSHRSA(crtKey, (RSAPublicKey) publicKey, comment, passphrase);
 			} catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
 				throw new InvalidKeyException("Failed to convert RSA key to CRT format", e);

--- a/src/main/java/com/trilead/ssh2/crypto/PEMEncoder.java
+++ b/src/main/java/com/trilead/ssh2/crypto/PEMEncoder.java
@@ -16,10 +16,14 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
+import java.security.KeyFactory;
 import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.ECFieldFp;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.util.Locale;
@@ -215,13 +219,12 @@ public class PEMEncoder {
 			throws IOException, InvalidKeyException {
 		if (privateKey instanceof RSAPrivateCrtKey) {
 			return encodeRSAPrivateKey((RSAPrivateCrtKey) privateKey, password, algorithm);
-		} else if (privateKey instanceof java.security.interfaces.RSAPrivateKey) {
+		} else if (privateKey instanceof RSAPrivateKey) {
 			// Handle non-CRT RSA keys (e.g., from Conscrypt's OpenSSLRSAPrivateKey)
 			try {
-				RSAPrivateCrtKey crtKey = convertToRSAPrivateCrtKey(
-						(java.security.interfaces.RSAPrivateKey) privateKey);
+				RSAPrivateCrtKey crtKey = convertToRSAPrivateCrtKey((RSAPrivateKey) privateKey);
 				return encodeRSAPrivateKey(crtKey, password, algorithm);
-			} catch (java.security.spec.InvalidKeySpecException | java.security.NoSuchAlgorithmException e) {
+			} catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
 				throw new InvalidKeyException("Failed to convert RSA key to CRT format", e);
 			}
 		} else if (privateKey instanceof DSAPrivateKey) {
@@ -269,17 +272,17 @@ public class PEMEncoder {
 	 *
 	 * @param privateKey The RSA private key to convert
 	 * @return The RSAPrivateCrtKey with CRT parameters
-	 * @throws java.security.spec.InvalidKeySpecException if the key cannot be parsed
-	 * @throws java.security.NoSuchAlgorithmException if RSA algorithm is not available
+	 * @throws InvalidKeySpecException if the key cannot be parsed
+	 * @throws NoSuchAlgorithmException if RSA algorithm is not available
 	 */
-	static RSAPrivateCrtKey convertToRSAPrivateCrtKey(java.security.interfaces.RSAPrivateKey privateKey)
-			throws java.security.spec.InvalidKeySpecException, java.security.NoSuchAlgorithmException {
+	static RSAPrivateCrtKey convertToRSAPrivateCrtKey(RSAPrivateKey privateKey)
+			throws InvalidKeySpecException, NoSuchAlgorithmException {
 		byte[] encoded = privateKey.getEncoded();
 		try {
 			SimpleDERReader reader = new SimpleDERReader(encoded);
 			reader.resetInput(reader.readSequenceAsByteArray());
 			if (!reader.readInt().equals(BigInteger.ZERO)) {
-				throw new java.security.spec.InvalidKeySpecException("PKCS#8 is not version 0");
+				throw new InvalidKeySpecException("PKCS#8 is not version 0");
 			}
 
 			reader.readSequenceAsByteArray(); // OID sequence
@@ -287,7 +290,7 @@ public class PEMEncoder {
 			reader.resetInput(reader.readSequenceAsByteArray()); // RSA key sequence
 
 			if (!reader.readInt().equals(BigInteger.ZERO)) {
-				throw new java.security.spec.InvalidKeySpecException("RSA key is not version 0");
+				throw new InvalidKeySpecException("RSA key is not version 0");
 			}
 
 			BigInteger modulus = reader.readInt();
@@ -299,14 +302,14 @@ public class PEMEncoder {
 			BigInteger primeExponentQ = reader.readInt();
 			BigInteger crtCoefficient = reader.readInt();
 
-			java.security.spec.RSAPrivateCrtKeySpec spec = new java.security.spec.RSAPrivateCrtKeySpec(
+			RSAPrivateCrtKeySpec spec = new RSAPrivateCrtKeySpec(
 					modulus, publicExponent, privateExponent,
 					primeP, primeQ, primeExponentP, primeExponentQ, crtCoefficient);
 
-			java.security.KeyFactory kf = java.security.KeyFactory.getInstance("RSA");
+			KeyFactory kf = KeyFactory.getInstance("RSA");
 			return (RSAPrivateCrtKey) kf.generatePrivate(spec);
 		} catch (IOException e) {
-			throw new java.security.spec.InvalidKeySpecException("Could not parse RSA key", e);
+			throw new InvalidKeySpecException("Could not parse RSA key", e);
 		}
 	}
 

--- a/src/main/java/com/trilead/ssh2/crypto/PEMEncoder.java
+++ b/src/main/java/com/trilead/ssh2/crypto/PEMEncoder.java
@@ -272,7 +272,7 @@ public class PEMEncoder {
 	 * @throws java.security.spec.InvalidKeySpecException if the key cannot be parsed
 	 * @throws java.security.NoSuchAlgorithmException if RSA algorithm is not available
 	 */
-	private static RSAPrivateCrtKey convertToRSAPrivateCrtKey(java.security.interfaces.RSAPrivateKey privateKey)
+	static RSAPrivateCrtKey convertToRSAPrivateCrtKey(java.security.interfaces.RSAPrivateKey privateKey)
 			throws java.security.spec.InvalidKeySpecException, java.security.NoSuchAlgorithmException {
 		byte[] encoded = privateKey.getEncoded();
 		try {

--- a/src/main/java/com/trilead/ssh2/crypto/PEMEncoder.java
+++ b/src/main/java/com/trilead/ssh2/crypto/PEMEncoder.java
@@ -4,6 +4,7 @@ import com.trilead.ssh2.crypto.cipher.AES;
 import com.trilead.ssh2.crypto.cipher.BlockCipher;
 import com.trilead.ssh2.crypto.cipher.DES;
 import com.trilead.ssh2.crypto.cipher.DESede;
+import com.trilead.ssh2.crypto.keys.Ed25519PrivateKey;
 import com.trilead.ssh2.signature.ECDSASHA2Verify;
 
 import java.io.IOException;
@@ -203,7 +204,7 @@ public class PEMEncoder {
 	/**
 	 * Encode private key to PEM format with auto-detected key type and specified algorithm.
 	 *
-	 * @param privateKey private key (RSA, DSA, or EC)
+	 * @param privateKey private key (RSA, DSA, EC, or Ed25519)
 	 * @param password password for encryption, or null for unencrypted
 	 * @param algorithm encryption algorithm
 	 * @return PEM-encoded private key
@@ -214,12 +215,98 @@ public class PEMEncoder {
 			throws IOException, InvalidKeyException {
 		if (privateKey instanceof RSAPrivateCrtKey) {
 			return encodeRSAPrivateKey((RSAPrivateCrtKey) privateKey, password, algorithm);
+		} else if (privateKey instanceof java.security.interfaces.RSAPrivateKey) {
+			// Handle non-CRT RSA keys (e.g., from Conscrypt's OpenSSLRSAPrivateKey)
+			try {
+				RSAPrivateCrtKey crtKey = convertToRSAPrivateCrtKey(
+						(java.security.interfaces.RSAPrivateKey) privateKey);
+				return encodeRSAPrivateKey(crtKey, password, algorithm);
+			} catch (java.security.spec.InvalidKeySpecException | java.security.NoSuchAlgorithmException e) {
+				throw new InvalidKeyException("Failed to convert RSA key to CRT format", e);
+			}
 		} else if (privateKey instanceof DSAPrivateKey) {
 			return encodeDSAPrivateKey((DSAPrivateKey) privateKey, password, algorithm);
 		} else if (privateKey instanceof ECPrivateKey) {
 			return encodeECPrivateKey((ECPrivateKey) privateKey, password, algorithm);
+		} else if (privateKey instanceof Ed25519PrivateKey) {
+			return encodeEd25519PrivateKey((Ed25519PrivateKey) privateKey, password, algorithm);
 		} else {
 			throw new InvalidKeyException("Unsupported key type: " + privateKey.getClass().getName());
+		}
+	}
+
+	/**
+	 * Encode Ed25519 private key to PEM format (PKCS#8).
+	 *
+	 * @param privateKey Ed25519 private key
+	 * @param password password for encryption, or null for unencrypted
+	 * @return PEM-encoded private key
+	 * @throws IOException if encoding fails
+	 */
+	public static String encodeEd25519PrivateKey(Ed25519PrivateKey privateKey, String password) throws IOException {
+		return encodeEd25519PrivateKey(privateKey, password, DEFAULT_ENCRYPTION);
+	}
+
+	/**
+	 * Encode Ed25519 private key to PEM format (PKCS#8) with specified encryption algorithm.
+	 *
+	 * @param privateKey Ed25519 private key
+	 * @param password password for encryption, or null for unencrypted
+	 * @param algorithm encryption algorithm
+	 * @return PEM-encoded private key
+	 * @throws IOException if encoding fails
+	 */
+	public static String encodeEd25519PrivateKey(Ed25519PrivateKey privateKey, String password, String algorithm)
+			throws IOException {
+		// Ed25519 uses PKCS#8 format (BEGIN PRIVATE KEY)
+		byte[] encoded = privateKey.getEncoded();
+		return formatPEM("PRIVATE KEY", encoded, password, algorithm);
+	}
+
+	/**
+	 * Converts an RSAPrivateKey to RSAPrivateCrtKey by parsing the PKCS#8 encoded form.
+	 * This is needed for keys from providers like Conscrypt that don't implement RSAPrivateCrtKey.
+	 *
+	 * @param privateKey The RSA private key to convert
+	 * @return The RSAPrivateCrtKey with CRT parameters
+	 * @throws java.security.spec.InvalidKeySpecException if the key cannot be parsed
+	 * @throws java.security.NoSuchAlgorithmException if RSA algorithm is not available
+	 */
+	private static RSAPrivateCrtKey convertToRSAPrivateCrtKey(java.security.interfaces.RSAPrivateKey privateKey)
+			throws java.security.spec.InvalidKeySpecException, java.security.NoSuchAlgorithmException {
+		byte[] encoded = privateKey.getEncoded();
+		try {
+			SimpleDERReader reader = new SimpleDERReader(encoded);
+			reader.resetInput(reader.readSequenceAsByteArray());
+			if (!reader.readInt().equals(BigInteger.ZERO)) {
+				throw new java.security.spec.InvalidKeySpecException("PKCS#8 is not version 0");
+			}
+
+			reader.readSequenceAsByteArray(); // OID sequence
+			reader.resetInput(reader.readOctetString()); // RSA key bytes
+			reader.resetInput(reader.readSequenceAsByteArray()); // RSA key sequence
+
+			if (!reader.readInt().equals(BigInteger.ZERO)) {
+				throw new java.security.spec.InvalidKeySpecException("RSA key is not version 0");
+			}
+
+			BigInteger modulus = reader.readInt();
+			BigInteger publicExponent = reader.readInt();
+			BigInteger privateExponent = reader.readInt();
+			BigInteger primeP = reader.readInt();
+			BigInteger primeQ = reader.readInt();
+			BigInteger primeExponentP = reader.readInt();
+			BigInteger primeExponentQ = reader.readInt();
+			BigInteger crtCoefficient = reader.readInt();
+
+			java.security.spec.RSAPrivateCrtKeySpec spec = new java.security.spec.RSAPrivateCrtKeySpec(
+					modulus, publicExponent, privateExponent,
+					primeP, primeQ, primeExponentP, primeExponentQ, crtCoefficient);
+
+			java.security.KeyFactory kf = java.security.KeyFactory.getInstance("RSA");
+			return (RSAPrivateCrtKey) kf.generatePrivate(spec);
+		} catch (IOException e) {
+			throw new java.security.spec.InvalidKeySpecException("Could not parse RSA key", e);
 		}
 	}
 


### PR DESCRIPTION
Fixes connectbot/connectbot#1812

This PR fixes SSH key export failures that occur when using security providers like Conscrypt, which return RSAPrivateKey impleme
ntations that don't implement RSAPrivateCrtKey (e.g., OpenSSLRSAPrivateKey). It also adds Ed25519 support to PEMEncoder.

  Problem

  When using the OSS build of ConnectBot (which uses Conscrypt's OpenSSL provider), exporting RSA keys fails with "Unsupported key
type" error because:
  - OpenSSHKeyEncoder.exportOpenSSH() only checked for RSAPrivateCrtKey
  - PEMEncoder.encodePrivateKey() only checked for RSAPrivateCrtKey
  - Conscrypt's OpenSSLRSAPrivateKey implements RSAPrivateKey but not RSAPrivateCrtKey

  Additionally, Ed25519 keys could not be exported in PEM format.

  Solution

  - Added handling for RSAPrivateKey (non-CRT) in both OpenSSHKeyEncoder and PEMEncoder
  - Parse the PKCS#8 encoded form to extract CRT parameters and convert to RSAPrivateCrtKey
  - Added encodeEd25519PrivateKey() to PEMEncoder using PKCS#8 format

  Changes

  | File                       | Description                                             |
  |----------------------------|---------------------------------------------------------|
  | OpenSSHKeyEncoder.java     | Handle non-CRT RSA keys via convertToRSAPrivateCrtKey() |
  | PEMEncoder.java            | Handle non-CRT RSA keys + add Ed25519 PKCS#8 encoding   |
  | OpenSSHKeyEncoderTest.java | Add tests for non-CRT RSA key export                    |
  | PEMEncoderTest.java        | Add tests for non-CRT RSA and Ed25519 encoding          |

  Testing

  - Added eight new tests covering non-CRT RSA and Ed25519 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)