### PR TITLE
Update Ed25519 decoding for other providers

### DIFF
--- a/src/test/java/com/trilead/ssh2/crypto/PublicKeyUtilsTest.java
+++ b/src/test/java/com/trilead/ssh2/crypto/PublicKeyUtilsTest.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -198,6 +201,45 @@ class PublicKeyUtilsTest {
 		assertNotNull(formatted);
 		assertTrue(formatted.startsWith("ssh-rsa "));
 		assertTrue(formatted.endsWith(" test"));
+	}
+
+	@Test
+	void testExtractPublicKeyBlobWithNativeJDKEdDSAKey() throws Exception {
+		KeyPairGenerator kpg;
+		try {
+			kpg = KeyPairGenerator.getInstance("EdDSA");
+		} catch (NoSuchAlgorithmException e) {
+			System.err.println("Skipping test: EdDSA not supported by this JDK");
+			return;
+		}
+
+		KeyPair keyPair = kpg.generateKeyPair();
+		PublicKey nativePublicKey = keyPair.getPublic();
+
+		byte[] blob = PublicKeyUtils.extractPublicKeyBlob(nativePublicKey);
+
+		assertNotNull(blob);
+		assertTrue(blob.length > 0);
+	}
+
+	@Test
+	void testToAuthorizedKeysFormatWithNativeJDKEdDSAKey() throws Exception {
+		KeyPairGenerator kpg;
+		try {
+			kpg = KeyPairGenerator.getInstance("EdDSA");
+		} catch (NoSuchAlgorithmException e) {
+			System.err.println("Skipping test: EdDSA not supported by this JDK");
+			return;
+		}
+
+		KeyPair keyPair = kpg.generateKeyPair();
+		PublicKey nativePublicKey = keyPair.getPublic();
+
+		String result = PublicKeyUtils.toAuthorizedKeysFormat(nativePublicKey, "native-eddsa-key");
+
+		assertNotNull(result);
+		assertTrue(result.startsWith("ssh-ed25519 "));
+		assertTrue(result.endsWith(" native-eddsa-key"));
 	}
 
 	private KeyPair loadKeyPair(String path) throws Exception {

--- a/src/test/java/com/trilead/ssh2/crypto/keys/Ed25519KeyFactoryTest.java
+++ b/src/test/java/com/trilead/ssh2/crypto/keys/Ed25519KeyFactoryTest.java
@@ -21,6 +21,23 @@ public class Ed25519KeyFactoryTest {
 	private static final byte[] KAT_ED25519_PRIV = toByteArray("f72a0a036e3479e15edb74da5f2a5418e66db450ad50687cad90247eeab6440c");
 	private static final byte[] KAT_ED25519_PUB = toByteArray("5386ea463b45fe14b4216f3f02a0a3f073b57724db10b86b65b2037e17b48c19");
 
+	private static final byte[] OPENSSL_PRIVATE = toByteArray("302e020100300506032b657004220420afd211ae1c8a61e212ddfc5cc59949f6c37ef2f683772c14088a2f8e7b54baf7");
+	private static final byte[] OPENSSL_PUBLIC = toByteArray("302a300506032b657003210006e59c37d4b0567863eb56397f7a2cfb78ae26a53dbd2206d83fb2c9cf1cbaea");
+	private static final byte[] OPENSSL_ED25519_PRIV = toByteArray("afd211ae1c8a61e212ddfc5cc59949f6c37ef2f683772c14088a2f8e7b54baf7");
+	private static final byte[] OPENSSL_ED25519_PUB = toByteArray("06e59c37d4b0567863eb56397f7a2cfb78ae26a53dbd2206d83fb2c9cf1cbaea");
+
+	// Generated with library version before commit 55e3ec98 (commit ce1cc53)
+	private static final byte[] OLD_LIB_PRIVATE = toByteArray("302e020100300506032b6570042204208fbad2fd15d27ca0a7b13c877d31b48e4a53ea55d9afc795f49696a50c389a77");
+	private static final byte[] OLD_LIB_PUBLIC = toByteArray("302a300506032b6570032100b018a2d34b081be789c9f1af3896dcc14f7c963d3ce9dd38f7d805865f09ca88");
+	private static final byte[] OLD_LIB_ED25519_PRIV = toByteArray("8fbad2fd15d27ca0a7b13c877d31b48e4a53ea55d9afc795f49696a50c389a77");
+	private static final byte[] OLD_LIB_ED25519_PUB = toByteArray("b018a2d34b081be789c9f1af3896dcc14f7c963d3ce9dd38f7d805865f09ca88");
+
+	// Legacy RAW format from commits f01a8b9 to 91bf5d0 (May-July 2020)
+	// Before 91bf5d0, getEncoded() returned just the raw 32-byte seed with format "RAW"
+	// This tests backward compatibility for keys stored during that 2-month period
+	private static final byte[] LEGACY_RAW_PRIVATE = toByteArray("afd211ae1c8a61e212ddfc5cc59949f6c37ef2f683772c14088a2f8e7b54baf7");
+	private static final byte[] LEGACY_RAW_PUBLIC = toByteArray("06e59c37d4b0567863eb56397f7a2cfb78ae26a53dbd2206d83fb2c9cf1cbaea");
+
 	private static byte[] toByteArray(String s) {
 		byte[] b = new byte[s.length() / 2];
 		for (int i = 0; i < b.length; i++) {
@@ -81,4 +98,105 @@ public class Ed25519KeyFactoryTest {
 		assertThat(((Ed25519PrivateKey) translatedPrivKey).getSeed(), is(((Ed25519PrivateKey) keyFactorySpi
 				.engineGeneratePrivate(new PKCS8EncodedKeySpec(nativePrivKey.getEncoded()))).getSeed()));
 	}
+
+	@Test
+	public void decodesOpenSSLGeneratedPrivateKey() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+		Ed25519PrivateKey pk = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(OPENSSL_PRIVATE));
+		assertThat(pk.getSeed(), is(OPENSSL_ED25519_PRIV));
+	}
+
+	@Test
+	public void decodesOpenSSLGeneratedPublicKey() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+		Ed25519PublicKey pub = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(OPENSSL_PUBLIC));
+		assertThat(pub.getAbyte(), is(OPENSSL_ED25519_PUB));
+	}
+
+	@Test
+	public void openSSLKeyRoundTrip() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+
+		Ed25519PrivateKey privateKey = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(OPENSSL_PRIVATE));
+		Ed25519PublicKey publicKey = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(OPENSSL_PUBLIC));
+
+		byte[] reEncodedPrivate = privateKey.getEncoded();
+		byte[] reEncodedPublic = publicKey.getEncoded();
+
+		assertArrayEquals(OPENSSL_PRIVATE, reEncodedPrivate);
+		assertArrayEquals(OPENSSL_PUBLIC, reEncodedPublic);
+
+		Ed25519PrivateKey privateKey2 = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(reEncodedPrivate));
+		Ed25519PublicKey publicKey2 = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(reEncodedPublic));
+
+		assertThat(privateKey2.getSeed(), is(OPENSSL_ED25519_PRIV));
+		assertThat(publicKey2.getAbyte(), is(OPENSSL_ED25519_PUB));
+	}
+
+	@Test
+	public void decodesOldLibraryGeneratedPrivateKey() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+		Ed25519PrivateKey pk = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(OLD_LIB_PRIVATE));
+		assertThat(pk.getSeed(), is(OLD_LIB_ED25519_PRIV));
+	}
+
+	@Test
+	public void decodesOldLibraryGeneratedPublicKey() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+		Ed25519PublicKey pub = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(OLD_LIB_PUBLIC));
+		assertThat(pub.getAbyte(), is(OLD_LIB_ED25519_PUB));
+	}
+
+	@Test
+	public void oldLibraryKeyRoundTrip() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+
+		Ed25519PrivateKey privateKey = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(OLD_LIB_PRIVATE));
+		Ed25519PublicKey publicKey = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(OLD_LIB_PUBLIC));
+
+		byte[] reEncodedPrivate = privateKey.getEncoded();
+		byte[] reEncodedPublic = publicKey.getEncoded();
+
+		assertArrayEquals(OLD_LIB_PRIVATE, reEncodedPrivate);
+		assertArrayEquals(OLD_LIB_PUBLIC, reEncodedPublic);
+
+		Ed25519PrivateKey privateKey2 = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(reEncodedPrivate));
+		Ed25519PublicKey publicKey2 = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(reEncodedPublic));
+
+		assertThat(privateKey2.getSeed(), is(OLD_LIB_ED25519_PRIV));
+		assertThat(publicKey2.getAbyte(), is(OLD_LIB_ED25519_PUB));
+	}
+
+	@Test
+	public void decodesLegacyRawFormatPrivateKey() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+
+		Ed25519PrivateKey pk = (Ed25519PrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(LEGACY_RAW_PRIVATE));
+
+		assertThat(pk.getSeed(), is(LEGACY_RAW_PRIVATE));
+
+		byte[] reEncoded = pk.getEncoded();
+		assertThat(reEncoded.length, is(48));
+	}
+
+	@Test
+	public void decodesLegacyRawFormatPublicKey() throws Exception {
+		Ed25519Provider p = new Ed25519Provider();
+		KeyFactory kf = KeyFactory.getInstance("Ed25519", p);
+
+		Ed25519PublicKey pub = (Ed25519PublicKey) kf.generatePublic(new X509EncodedKeySpec(LEGACY_RAW_PUBLIC));
+
+		assertThat(pub.getAbyte(), is(LEGACY_RAW_PUBLIC));
+
+		byte[] reEncoded = pub.getEncoded();
+		assertThat(reEncoded.length, is(44));
+	}
+
 }

--- a/src/test/java/com/trilead/ssh2/signature/Ed25519VerifyTest.java
+++ b/src/test/java/com/trilead/ssh2/signature/Ed25519VerifyTest.java
@@ -223,4 +223,44 @@ public class Ed25519VerifyTest {
 		Ed25519PrivateKey convertedPrivKey = new Ed25519PrivateKey(privKeySpec);
 		assertArrayEquals(nativePrivKey.getEncoded(), convertedPrivKey.getEncoded());
 	}
+
+	@Test
+	public void opensslGeneratedKeySignAndVerify() throws Exception {
+		byte[] opensslPrivate = toByteArray("302e020100300506032b657004220420afd211ae1c8a61e212ddfc5cc59949f6c37ef2f683772c14088a2f8e7b54baf7");
+		byte[] opensslPublic = toByteArray("302a300506032b657003210006e59c37d4b0567863eb56397f7a2cfb78ae26a53dbd2206d83fb2c9cf1cbaea");
+
+		Ed25519PrivateKey privateKey = new Ed25519PrivateKey(new PKCS8EncodedKeySpec(opensslPrivate));
+		Ed25519PublicKey publicKey = new Ed25519PublicKey(new X509EncodedKeySpec(opensslPublic));
+
+		byte[] message = "Test message for OpenSSL-generated Ed25519 key".getBytes();
+
+		Ed25519Verify verifier = Ed25519Verify.get();
+		byte[] signature = verifier.generateSignature(message, privateKey, new SecureRandom());
+
+		assertTrue(verifier.verifySignature(message, signature, publicKey));
+
+		byte[] tampered = Arrays.copyOf(message, message.length);
+		tampered[0] ^= 1;
+		assertFalse(verifier.verifySignature(tampered, signature, publicKey));
+	}
+
+	@Test
+	public void oldLibraryGeneratedKeySignAndVerify() throws Exception {
+		byte[] oldLibPrivate = toByteArray("302e020100300506032b6570042204208fbad2fd15d27ca0a7b13c877d31b48e4a53ea55d9afc795f49696a50c389a77");
+		byte[] oldLibPublic = toByteArray("302a300506032b6570032100b018a2d34b081be789c9f1af3896dcc14f7c963d3ce9dd38f7d805865f09ca88");
+
+		Ed25519PrivateKey privateKey = new Ed25519PrivateKey(new PKCS8EncodedKeySpec(oldLibPrivate));
+		Ed25519PublicKey publicKey = new Ed25519PublicKey(new X509EncodedKeySpec(oldLibPublic));
+
+		byte[] message = "Test message for old library-generated Ed25519 key".getBytes();
+
+		Ed25519Verify verifier = Ed25519Verify.get();
+		byte[] signature = verifier.generateSignature(message, privateKey, new SecureRandom());
+
+		assertTrue(verifier.verifySignature(message, signature, publicKey));
+
+		byte[] tampered = Arrays.copyOf(message, message.length);
+		tampered[0] ^= 1;
+		assertFalse(verifier.verifySignature(tampered, signature, publicKey));
+	}
 }


### PR DESCRIPTION
Now that other providers are using Ed25519, we need to make sure we are compatible with them. Use SimpleDERReader for the parsing instead of hand-writing the types comparison.

Also add compatibility for the older Ed25519 keys that were just 32-byte seed values from this library. This shouldn't conflict with the new PKCS#8 format since that is always >=48 bytes.

Re: https://github.com/connectbot/connectbot/issues/1822